### PR TITLE
feat: gate game participation on visibility and viewer role

### DIFF
--- a/src/components/game/game-participants.tsx
+++ b/src/components/game/game-participants.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
 import {
+  GameVisibility,
   getMaxParticipants,
   getParticipationType,
   getSubtypeFromMetadata,
@@ -58,7 +59,7 @@ export function GameParticipants({
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle>{t("game.participants.title")}</CardTitle>
-          {isTeamBased && !atParticipantLimit && (
+          {isTeamBased && !atParticipantLimit && (game.viewerGameRole != null || game.visibility === GameVisibility.PUBLIC) && (
             <Button onClick={() => setShowAddTeamDialog(true)} size="sm">
               {t("game.participants.addTeam")}
             </Button>
@@ -89,6 +90,8 @@ export function GameParticipants({
                     gameStatus={game.gameStatus}
                     currentPlayerId={currentPlayerId}
                     isPlayerOnAnyTeam={isPlayerOnAnyTeam}
+                    viewerGameRole={game.viewerGameRole}
+                    visibility={game.visibility}
                   />
                 );
               }
@@ -103,6 +106,8 @@ export function GameParticipants({
             gameId={game.id}
             currentPlayerId={currentPlayerId}
             atParticipantLimit={atParticipantLimit}
+            viewerGameRole={game.viewerGameRole}
+            visibility={game.visibility}
           />
         )}
       </CardContent>

--- a/src/components/game/individual-participant-list.tsx
+++ b/src/components/game/individual-participant-list.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/app/[locale]/game/participant-actions";
 import { Button } from "@/components/ui/button";
 import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
+import { GameRole, GameVisibility } from "@/lib/constants";
 import type { GameParticipantDetail } from "@/lib/types/game";
 import { UserPlus, X } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -17,6 +18,8 @@ interface IndividualParticipantListProps {
   gameId: number;
   currentPlayerId: number;
   atParticipantLimit: boolean;
+  viewerGameRole: GameRole | null;
+  visibility: GameVisibility;
 }
 
 export function IndividualParticipantList({
@@ -24,6 +27,8 @@ export function IndividualParticipantList({
   gameId,
   currentPlayerId,
   atParticipantLimit,
+  viewerGameRole,
+  visibility,
 }: IndividualParticipantListProps) {
   const t = useTranslations();
   const [isPending, startTransition] = useTransition();
@@ -38,6 +43,11 @@ export function IndividualParticipantList({
       p.__typename === "IndividualParticipant" &&
       p.player.id === currentPlayerId,
   );
+
+  const canJoin =
+    !atParticipantLimit &&
+    !isCurrentPlayerParticipant &&
+    (viewerGameRole != null || visibility === GameVisibility.PUBLIC);
 
   const handleJoinGame = () => {
     startTransition(async () => {
@@ -98,7 +108,7 @@ export function IndividualParticipantList({
             {t("game.participants.leaveGame")}
           </Button>
         ) : (
-          !atParticipantLimit && (
+          canJoin && (
             <Button
               variant="default"
               size="sm"
@@ -135,17 +145,19 @@ export function IndividualParticipantList({
                 className="flex items-center justify-between rounded-lg border p-3"
               >
                 <p className="font-medium">{playerName}</p>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleRemoveParticipant(player.id)}
-                  disabled={isPending}
-                >
-                  <X className="h-4 w-4" />
-                  <span className="sr-only">
-                    {t("game.participants.removeParticipant")}
-                  </span>
-                </Button>
+                {viewerGameRole != null && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveParticipant(player.id)}
+                    disabled={isPending}
+                  >
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">
+                      {t("game.participants.removeParticipant")}
+                    </span>
+                  </Button>
+                )}
               </div>
             );
           })}

--- a/src/components/game/team-card.tsx
+++ b/src/components/game/team-card.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { GameStatus } from "@/lib/constants";
+import { GameRole, GameStatus, GameVisibility } from "@/lib/constants";
 import type { TeamInstanceDetail } from "@/lib/types/game";
 import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
@@ -29,6 +29,8 @@ interface TeamCardProps {
   gameStatus: GameStatus;
   currentPlayerId: number;
   isPlayerOnAnyTeam: boolean;
+  viewerGameRole: GameRole | null;
+  visibility: GameVisibility;
 }
 
 export function TeamCard({
@@ -37,6 +39,8 @@ export function TeamCard({
   gameStatus,
   currentPlayerId,
   isPlayerOnAnyTeam,
+  viewerGameRole,
+  visibility,
 }: TeamCardProps) {
   const t = useTranslations();
   const [isPending, startTransition] = useTransition();
@@ -120,7 +124,7 @@ export function TeamCard({
                   {t("game.participants.leaveTeam")}
                 </Button>
               ) : (
-                !isPlayerOnAnyTeam && (
+                !isPlayerOnAnyTeam && (viewerGameRole != null || visibility === GameVisibility.PUBLIC) && (
                   <Button
                     variant="default"
                     size="sm"
@@ -131,14 +135,16 @@ export function TeamCard({
                   </Button>
                 )
               )}
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => setShowRemoveDialog(true)}
-                disabled={isPending}
-              >
-                {t("game.participants.removeTeam")}
-              </Button>
+              {viewerGameRole != null && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setShowRemoveDialog(true)}
+                  disabled={isPending}
+                >
+                  {t("game.participants.removeTeam")}
+                </Button>
+              )}
             </div>
           </div>
         </CardHeader>


### PR DESCRIPTION
## Summary
- Gate "Add Team", "Join Game", and "Join Team" buttons on `viewerGameRole != null || visibility === PUBLIC`
- Gate "Remove Participant" and "Remove Team" buttons on `viewerGameRole != null` (editors/owners only)
- Leave buttons remain always visible for current participants/team members

## Test plan
- [ ] Verify public game: any user can see join buttons
- [ ] Verify private game: only editors/owners see join buttons
- [ ] Verify remove buttons only appear for editors/owners
- [ ] Verify leave buttons always appear for current participants
- [ ] Run `npm run build` — passes clean

Final pull request for https://github.com/kevinlee2198/playground-web-client/issues/34