### PR TITLE
feat: add volleyball sport type

### DIFF
--- a/__tests__/components/game/game-score-block.test.tsx
+++ b/__tests__/components/game/game-score-block.test.tsx
@@ -97,6 +97,26 @@ vi.mock("@/components/game/scoreboard/tennis-score-form", () => ({
   ),
 }));
 
+vi.mock("@/components/game/scoreboard/volleyball-score-form", () => ({
+  VolleyballScoreForm: ({
+    onSuccess,
+    onCancel,
+  }: {
+    onSuccess: () => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="volleyball-score-form">
+      <input data-testid="form-input" />
+      <button data-testid="save-btn" onClick={onSuccess}>
+        Save
+      </button>
+      <button data-testid="cancel-btn" onClick={onCancel}>
+        Cancel
+      </button>
+    </div>
+  ),
+}));
+
 import { GameScoreBlock } from "@/components/game/game-score-block";
 import {
   GameRole,
@@ -413,5 +433,68 @@ describe("GameScoreBlock", () => {
 
     const liveRegion = container.querySelector("[aria-live='polite']");
     expect(liveRegion).not.toBeInTheDocument();
+  });
+
+  it("toggles to volleyball score form when edit pencil is clicked", () => {
+    render(
+      <GameScoreBlock
+        game={makeGame({
+          sportType: SportType.VOLLEYBALL,
+          metadata: {
+            __typename: "VolleyballGameMetadata",
+            volleyballFormat: SportFormat.INDOOR,
+            volleyballBestOf: 5,
+            pointsPerSet: 25,
+            pointsPerFinalSet: 15,
+            winByTwo: true,
+          },
+          participants: {
+            edges: [
+              {
+                cursor: "c1",
+                node: {
+                  __typename: "TeamInstance",
+                  id: 10,
+                  name: "Team Alpha",
+                  description: null,
+                  players: [],
+                  metadata: {
+                    __typename: "VolleyballParticipantMetadata",
+                    setsWon: 2,
+                    sets: [{ pointsScored: 25 }, { pointsScored: 25 }],
+                  },
+                },
+              },
+              {
+                cursor: "c2",
+                node: {
+                  __typename: "TeamInstance",
+                  id: 11,
+                  name: "Team Beta",
+                  description: null,
+                  players: [],
+                  metadata: {
+                    __typename: "VolleyballParticipantMetadata",
+                    setsWon: 1,
+                    sets: [{ pointsScored: 20 }, { pointsScored: 18 }],
+                  },
+                },
+              },
+            ],
+            pageInfo: {
+              hasPreviousPage: false,
+              hasNextPage: false,
+              startCursor: "c1",
+              endCursor: "c2",
+            },
+          },
+        })}
+        statusPill={<span>Live</span>}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit Score" }));
+
+    expect(screen.getByTestId("volleyball-score-form")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/game/score/volleyball-score.test.tsx
+++ b/__tests__/components/game/score/volleyball-score.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VolleyballScore } from "@/components/game/score/volleyball-score";
+import type { GameParticipant } from "@/lib/types/game";
+
+function makeParticipant(
+  id: number,
+  name: string,
+  setsWon: number,
+  sets: { pointsScored: number }[],
+): GameParticipant {
+  return {
+    __typename: "TeamInstance",
+    id,
+    name,
+    players: [],
+    metadata: {
+      __typename: "VolleyballParticipantMetadata",
+      setsWon,
+      sets,
+    },
+  };
+}
+
+describe("VolleyballScore", () => {
+  it("renders sets won for both teams", () => {
+    const a = makeParticipant(1, "Team A", 3, [
+      { pointsScored: 25 },
+      { pointsScored: 23 },
+      { pointsScored: 25 },
+    ]);
+    const b = makeParticipant(2, "Team B", 0, [
+      { pointsScored: 20 },
+      { pointsScored: 25 },
+      { pointsScored: 18 },
+    ]);
+
+    render(<VolleyballScore participantA={a} participantB={b} />);
+
+    expect(screen.getByText("Team A")).toBeInTheDocument();
+    expect(screen.getByText("Team B")).toBeInTheDocument();
+  });
+
+  it("renders per-set scores as pills", () => {
+    const a = makeParticipant(1, "Team A", 2, [
+      { pointsScored: 25 },
+      { pointsScored: 25 },
+    ]);
+    const b = makeParticipant(2, "Team B", 0, [
+      { pointsScored: 20 },
+      { pointsScored: 18 },
+    ]);
+
+    render(<VolleyballScore participantA={a} participantB={b} />);
+
+    expect(screen.getByText("25-20")).toBeInTheDocument();
+    expect(screen.getByText("25-18")).toBeInTheDocument();
+  });
+
+  it("does not render set pills when no sets exist", () => {
+    const a = makeParticipant(1, "Team A", 0, []);
+    const b = makeParticipant(2, "Team B", 0, []);
+
+    const { container } = render(
+      <VolleyballScore participantA={a} participantB={b} />,
+    );
+
+    const pills = container.querySelectorAll(".rounded-full");
+    expect(pills.length).toBe(0);
+  });
+
+  it("renders nothing when both participants have no metadata", () => {
+    const a: GameParticipant = {
+      __typename: "TeamInstance",
+      id: 1,
+      name: "Team A",
+      players: [],
+      metadata: null,
+    };
+    const b: GameParticipant = {
+      __typename: "TeamInstance",
+      id: 2,
+      name: "Team B",
+      players: [],
+      metadata: null,
+    };
+
+    render(<VolleyballScore participantA={a} participantB={b} />);
+
+    // setsWon defaults to 0 for both
+    expect(screen.getByText("Team A")).toBeInTheDocument();
+    expect(screen.getByText("Team B")).toBeInTheDocument();
+  });
+
+  it("renders status pill when provided", () => {
+    const a = makeParticipant(1, "Team A", 1, [{ pointsScored: 25 }]);
+    const b = makeParticipant(2, "Team B", 0, [{ pointsScored: 20 }]);
+
+    render(
+      <VolleyballScore
+        participantA={a}
+        participantB={b}
+        statusPill={<span data-testid="pill">Live</span>}
+      />,
+    );
+
+    expect(screen.getByTestId("pill")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/game/sport-badge.test.tsx
+++ b/__tests__/components/game/sport-badge.test.tsx
@@ -9,6 +9,7 @@ vi.mock("next-intl", () => ({
       "sports.FOOTBALL": "Football",
       "sports.PICKLEBALL": "Pickleball",
       "sports.BASEBALL": "Baseball",
+      "sports.VOLLEYBALL": "Volleyball",
     };
     return map[key] ?? key;
   },
@@ -25,6 +26,7 @@ describe("SportBadge", () => {
       FOOTBALL: "Football",
       PICKLEBALL: "Pickleball",
       BASEBALL: "Baseball",
+      VOLLEYBALL: "Volleyball",
     };
     for (const sport of Object.values(SportType)) {
       const { unmount } = render(<SportBadge sportType={sport} />);

--- a/messages/en.json
+++ b/messages/en.json
@@ -34,7 +34,8 @@
     "FOOTBALL": "Football",
     "TENNIS": "Tennis",
     "PICKLEBALL": "Pickleball",
-    "BASEBALL": "Baseball"
+    "BASEBALL": "Baseball",
+    "VOLLEYBALL": "Volleyball"
   },
   "sportFormats": {
     "FIVE_ON_FIVE": "5v5",
@@ -42,7 +43,9 @@
     "FLAG_FOOTBALL": "Flag Football",
     "AMERICAN_FOOTBALL": "American Football",
     "SINGLES": "Singles",
-    "DOUBLES": "Doubles"
+    "DOUBLES": "Doubles",
+    "INDOOR": "Indoor",
+    "BEACH": "Beach"
   },
   "profile": {
     "title": "Profile",
@@ -228,7 +231,11 @@
       "selectScoringType": "Select scoring type",
       "location": "Location",
       "innings": "Number of Innings",
-      "inningsPlaceholder": "Default: 9"
+      "inningsPlaceholder": "Default: 9",
+      "pointsPerSet": "Points Per Set",
+      "pointsPerSetPlaceholder": "Default: 25",
+      "pointsPerFinalSet": "Points Per Final Set",
+      "pointsPerFinalSetPlaceholder": "Default: 15"
     },
     "status": {
       "scheduled": "Scheduled",
@@ -517,6 +524,20 @@
           "pitching": "Pitching",
           "fielding": "Fielding"
         }
+      },
+      "volleyball": {
+        "kills": "K",
+        "attackErrors": "AE",
+        "attackAttempts": "ATT",
+        "hittingPercentage": "HIT%",
+        "aces": "SA",
+        "serviceErrors": "SE",
+        "blocks": "BS",
+        "blockErrors": "BE",
+        "digs": "DIG",
+        "receptionErrors": "RE",
+        "assists": "AST",
+        "points": "PTS"
       }
     },
     "media": {
@@ -1009,7 +1030,8 @@
         "basketball": "Basketball",
         "football": "Football",
         "tennis": "Tennis",
-        "pickleball": "Pickleball"
+        "pickleball": "Pickleball",
+        "volleyball": "Volleyball"
       }
     },
     "notifications": {

--- a/src/app/[locale]/game/[id]/page.tsx
+++ b/src/app/[locale]/game/[id]/page.tsx
@@ -29,6 +29,7 @@ import type {
 } from "@/lib/types/stats/football";
 import type { PickleballStatisticsNode } from "@/lib/types/stats/pickleball";
 import type { TennisStatisticsNode } from "@/lib/types/stats/tennis";
+import type { VolleyballStatisticsNode } from "@/lib/types/stats/volleyball";
 import type {
   BaseballBattingStatsNode,
   BaseballPitchingStatsNode,
@@ -172,6 +173,7 @@ export default async function GameDetailPage({ params }: PageProps) {
   let initialBaseballBattingStats: { node: BaseballBattingStatsNode }[] = [];
   let initialBaseballPitchingStats: { node: BaseballPitchingStatsNode }[] = [];
   let initialBaseballFieldingStats: { node: BaseballFieldingStatsNode }[] = [];
+  let initialVolleyballStats: { node: VolleyballStatisticsNode }[] = [];
 
   if (session?.user) {
     if (
@@ -244,6 +246,36 @@ export default async function GameDetailPage({ params }: PageProps) {
       });
       initialPickleballStats =
         statsResponse.data?.pickleballStatistics?.edges ?? [];
+    }
+
+    if (
+      game.sportType === SportType.VOLLEYBALL &&
+      game.gameStatus !== GameStatus.SCHEDULED
+    ) {
+      const volleyballStatsResponse = await authQuery({
+        volleyballStatistics: {
+          __args: { input: { gameIds: [game.id] }, first: 50 },
+          edges: {
+            node: {
+              id: true,
+              player: playerRefFragment,
+              kills: true,
+              attackErrors: true,
+              attackAttempts: true,
+              aces: true,
+              serviceErrors: true,
+              blocks: true,
+              blockErrors: true,
+              digs: true,
+              receptionErrors: true,
+              assists: true,
+              points: true,
+            },
+          },
+        },
+      });
+      initialVolleyballStats =
+        volleyballStatsResponse.data?.volleyballStatistics?.edges ?? [];
     }
 
     if (
@@ -469,6 +501,7 @@ export default async function GameDetailPage({ params }: PageProps) {
         initialBaseballBattingStats={initialBaseballBattingStats}
         initialBaseballPitchingStats={initialBaseballPitchingStats}
         initialBaseballFieldingStats={initialBaseballFieldingStats}
+        initialVolleyballStats={initialVolleyballStats}
         playerId={playerId}
         currentUserId={currentUserId}
       >

--- a/src/app/[locale]/game/actions.ts
+++ b/src/app/[locale]/game/actions.ts
@@ -58,7 +58,8 @@ export async function createGame(
       | "basketball"
       | "football"
       | "tennis"
-      | "pickleball";
+      | "pickleball"
+      | "volleyball";
     const metadata: Record<string, unknown> = {};
     if ("format" in input.metadata && input.metadata.format !== undefined) {
       metadata.format = new EnumType(input.metadata.format);
@@ -95,6 +96,18 @@ export async function createGame(
       input.metadata.scoringType !== undefined
     ) {
       metadata.scoringType = new EnumType(input.metadata.scoringType);
+    }
+    if (
+      "pointsPerSet" in input.metadata &&
+      input.metadata.pointsPerSet !== undefined
+    ) {
+      metadata.pointsPerSet = input.metadata.pointsPerSet;
+    }
+    if (
+      "pointsPerFinalSet" in input.metadata &&
+      input.metadata.pointsPerFinalSet !== undefined
+    ) {
+      metadata.pointsPerFinalSet = input.metadata.pointsPerFinalSet;
     }
 
     const sportInput: Record<string, unknown> = {
@@ -211,6 +224,19 @@ export async function updateGame(
         if (input.metadata.pickleball.scoringType !== undefined)
           p.scoringType = new EnumType(input.metadata.pickleball.scoringType);
         metadataInput.pickleball = p;
+      } else if (input.metadata.volleyball) {
+        const v: Record<string, unknown> = {};
+        if (input.metadata.volleyball.format)
+          v.format = new EnumType(input.metadata.volleyball.format);
+        if (input.metadata.volleyball.bestOf !== undefined)
+          v.bestOf = input.metadata.volleyball.bestOf;
+        if (input.metadata.volleyball.pointsPerSet !== undefined)
+          v.pointsPerSet = input.metadata.volleyball.pointsPerSet;
+        if (input.metadata.volleyball.pointsPerFinalSet !== undefined)
+          v.pointsPerFinalSet = input.metadata.volleyball.pointsPerFinalSet;
+        if (input.metadata.volleyball.winByTwo !== undefined)
+          v.winByTwo = input.metadata.volleyball.winByTwo;
+        metadataInput.volleyball = v;
       } else if (input.metadata.baseball) {
         const bb: Record<string, unknown> = {};
         if (input.metadata.baseball.innings !== undefined)

--- a/src/app/[locale]/game/volleyball-stats-actions.ts
+++ b/src/app/[locale]/game/volleyball-stats-actions.ts
@@ -1,0 +1,148 @@
+"use server";
+
+import { errorFragment } from "@/lib/graphql-fragments";
+import { authMutate } from "@/lib/graphql-request";
+import { extractMutationResult, MutationErrorType } from "@/lib/graphql-result";
+import type { SaveVolleyballStatisticsData, SaveVolleyballStatisticsInput } from "@/lib/types/stats/volleyball";
+import { revalidatePath } from "next/cache";
+
+interface VolleyballStatsActionResult {
+  success: boolean;
+  statisticsId?: string;
+  statisticsIds?: string[];
+  errorType?: string;
+  message?: string;
+}
+
+const STAT_FIELDS = [
+  "kills",
+  "attackErrors",
+  "attackAttempts",
+  "aces",
+  "serviceErrors",
+  "blocks",
+  "blockErrors",
+  "digs",
+  "receptionErrors",
+  "assists",
+] as const;
+
+function buildStatFields(
+  data: SaveVolleyballStatisticsData,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const field of STAT_FIELDS) {
+    if (data[field] !== undefined) {
+      result[field] = data[field];
+    }
+  }
+  return result;
+}
+
+const RESPONSE_FIELDS = {
+  id: true,
+  player: { id: true, user: { displayName: true } },
+  kills: true,
+  attackErrors: true,
+  attackAttempts: true,
+  aces: true,
+  serviceErrors: true,
+  blocks: true,
+  blockErrors: true,
+  digs: true,
+  receptionErrors: true,
+  assists: true,
+  points: true,
+} as const;
+
+/**
+ * Save a single set of volleyball statistics
+ */
+export async function saveVolleyballStatistics(
+  input: SaveVolleyballStatisticsInput,
+): Promise<VolleyballStatsActionResult> {
+  try {
+    const mutationInput: Record<string, unknown> = {
+      playerId: input.playerId,
+      gameId: input.gameId,
+      ...buildStatFields(input),
+    };
+
+    const response = await authMutate({
+      saveVolleyballStatistics: {
+        __args: { input: mutationInput },
+        __typename: true,
+        __on: [
+          {
+            __typeName: "SaveVolleyballStatisticsResponse",
+            volleyballStatistics: RESPONSE_FIELDS,
+          },
+          errorFragment,
+        ],
+      },
+    });
+
+    if (response.errors?.length > 0) {
+      return { success: false, errorType: MutationErrorType.GRAPHQL_ERROR, message: response.errors[0].message };
+    }
+
+    const result = extractMutationResult(response.data.saveVolleyballStatistics, "SaveVolleyballStatisticsResponse");
+    if (!result.success) return result;
+
+    revalidatePath("/[locale]/game/[id]", "page");
+    return { success: true, statisticsId: result.data.volleyballStatistics.id };
+  } catch (error) {
+    console.error("Failed to save volleyball statistics:", error);
+    return { success: false, errorType: MutationErrorType.UNEXPECTED_ERROR, message: "Failed to save volleyball statistics" };
+  }
+}
+
+/**
+ * Save multiple sets of volleyball statistics
+ */
+export async function saveVolleyballStatisticsBulk(
+  gameId: number,
+  statistics: SaveVolleyballStatisticsData[],
+): Promise<VolleyballStatsActionResult> {
+  try {
+    if (statistics.length === 0) {
+      return { success: false, errorType: MutationErrorType.VALIDATION_ERROR, message: "No statistics provided" };
+    }
+
+    const statisticsInput = statistics.map((stat) => ({
+      playerId: stat.playerId,
+      ...buildStatFields(stat),
+    }));
+
+    const response = await authMutate({
+      saveVolleyballStatisticsBulk: {
+        __args: { input: { gameId, statistics: statisticsInput } },
+        __typename: true,
+        __on: [
+          {
+            __typeName: "SaveVolleyballStatisticsBulkResponse",
+            statistics: RESPONSE_FIELDS,
+          },
+          errorFragment,
+        ],
+      },
+    });
+
+    if (response.errors?.length > 0) {
+      return { success: false, errorType: MutationErrorType.GRAPHQL_ERROR, message: response.errors[0].message };
+    }
+
+    const result = extractMutationResult(response.data.saveVolleyballStatisticsBulk, "SaveVolleyballStatisticsBulkResponse");
+    if (!result.success) return result;
+
+    const statisticsIds = result.data.statistics.map(
+      (stat: { id: string }) => stat.id,
+    );
+
+    revalidatePath("/[locale]/game/[id]", "page");
+    return { success: true, statisticsIds };
+  } catch (error) {
+    console.error("Failed to save volleyball statistics bulk:", error);
+    return { success: false, errorType: MutationErrorType.UNEXPECTED_ERROR, message: "Failed to save volleyball statistics" };
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,8 @@
   --color-sport-pickleball-foreground: var(--sport-pickleball-foreground);
   --color-sport-baseball: var(--sport-baseball);
   --color-sport-baseball-foreground: var(--sport-baseball-foreground);
+  --color-sport-volleyball: var(--sport-volleyball);
+  --color-sport-volleyball-foreground: var(--sport-volleyball-foreground);
   --color-live: var(--live);
   --color-live-foreground: var(--live-foreground);
   --radius-sm: calc(var(--radius) - 4px);
@@ -120,6 +122,8 @@
   --sport-pickleball-foreground: oklch(0.52 0.12 95);
   --sport-baseball: oklch(0.92 0.04 20);
   --sport-baseball-foreground: oklch(0.55 0.12 20);
+  --sport-volleyball: oklch(0.92 0.04 185);
+  --sport-volleyball-foreground: oklch(0.52 0.10 185);
 
   /* Live indicator */
   --live: oklch(0.60 0.14 45);
@@ -186,6 +190,8 @@
   --sport-pickleball-foreground: oklch(0.70 0.12 95);
   --sport-baseball: oklch(0.35 0.04 20);
   --sport-baseball-foreground: oklch(0.70 0.10 20);
+  --sport-volleyball: oklch(0.35 0.04 185);
+  --sport-volleyball-foreground: oklch(0.70 0.10 185);
 
   --live: oklch(0.70 0.14 45);
   --live-foreground: oklch(0.20 0.02 55);

--- a/src/components/game/create-game-form.tsx
+++ b/src/components/game/create-game-form.tsx
@@ -69,6 +69,8 @@ export function CreateGameForm({ onSuccess }: CreateGameFormProps) {
       winByTwo: undefined as boolean | undefined,
       scoringType: undefined as PickleballScoringType | undefined,
       innings: undefined as number | undefined,
+      pointsPerSet: undefined as number | undefined,
+      pointsPerFinalSet: undefined as number | undefined,
       location: undefined as LocationValue | undefined,
       visibility: GameVisibility.PUBLIC,
       statEntryMode: StatEntryMode.OPEN,
@@ -140,6 +142,28 @@ export function CreateGameForm({ onSuccess }: CreateGameFormProps) {
               }),
               ...(value.scoringType !== undefined && {
                 scoringType: value.scoringType,
+              }),
+            },
+          };
+        } else if (sportType === SportType.VOLLEYBALL) {
+          input = {
+            sportType: SportType.VOLLEYBALL,
+            startDate: value.startDate.toISOString(),
+            visibility: value.visibility,
+            statEntryMode: value.statEntryMode,
+            metadata: {
+              format: value.format as
+                | SportFormat.INDOOR
+                | SportFormat.BEACH,
+              ...(value.bestOf !== undefined && { bestOf: value.bestOf }),
+              ...(value.pointsPerSet !== undefined && {
+                pointsPerSet: value.pointsPerSet,
+              }),
+              ...(value.pointsPerFinalSet !== undefined && {
+                pointsPerFinalSet: value.pointsPerFinalSet,
+              }),
+              ...(value.winByTwo !== undefined && {
+                winByTwo: value.winByTwo,
               }),
             },
           };
@@ -497,6 +521,81 @@ export function CreateGameForm({ onSuccess }: CreateGameFormProps) {
                         />
                       )}
                     </Field>
+                  )}
+                </form.Field>
+                <form.Field name="winByTwo">
+                  {(field) => (
+                    <FormSwitchField
+                      field={field}
+                      label={t("game.form.winByTwo")}
+                      disabled={isPending}
+                    />
+                  )}
+                </form.Field>
+              </>
+            )}
+
+            {selectedSportType === SportType.VOLLEYBALL && (
+              <>
+                <form.Field name="bestOf">
+                  {(field) => (
+                    <Field
+                      data-invalid={
+                        field.state.meta.isTouched &&
+                        field.state.meta.errors.length > 0
+                          ? true
+                          : undefined
+                      }
+                    >
+                      <FieldLabel htmlFor={field.name}>
+                        {t("game.form.bestOf")}
+                      </FieldLabel>
+                      <Select
+                        value={field.state.value?.toString() ?? null}
+                        onValueChange={(v) => {
+                          field.handleChange(Number(v));
+                          field.handleBlur();
+                        }}
+                        disabled={isPending}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue
+                            placeholder={t("game.form.bestOfPlaceholder")}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="3">3</SelectItem>
+                          <SelectItem value="5">5</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      {field.state.meta.isTouched && (
+                        <FieldError
+                          errors={toFieldErrors(field.state.meta.errors)}
+                        />
+                      )}
+                    </Field>
+                  )}
+                </form.Field>
+                <form.Field name="pointsPerSet">
+                  {(field) => (
+                    <FormTextField
+                      field={field}
+                      label={t("game.form.pointsPerSet")}
+                      type="number"
+                      disabled={isPending}
+                      placeholder={t("game.form.pointsPerSetPlaceholder")}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="pointsPerFinalSet">
+                  {(field) => (
+                    <FormTextField
+                      field={field}
+                      label={t("game.form.pointsPerFinalSet")}
+                      type="number"
+                      disabled={isPending}
+                      placeholder={t("game.form.pointsPerFinalSetPlaceholder")}
+                    />
                   )}
                 </form.Field>
                 <form.Field name="winByTwo">

--- a/src/components/game/game-box-scores.tsx
+++ b/src/components/game/game-box-scores.tsx
@@ -10,6 +10,7 @@ import { BaseballPitchingStatsTable } from "@/components/game/baseball-pitching-
 import { BaseballFieldingStatsTable } from "@/components/game/baseball-fielding-stats-table";
 import { PickleballStatsTable } from "@/components/game/pickleball-stats-table";
 import { TennisStatsTable } from "@/components/game/tennis-stats-table";
+import { VolleyballStatsTable } from "@/components/game/volleyball-stats-table";
 import { TypographyH4 } from "@/components/ui/typography";
 import { GameStatus, SportType } from "@/lib/constants";
 import type {
@@ -32,6 +33,7 @@ import type {
   BaseballPitchingStatsNode,
   BaseballFieldingStatsNode,
 } from "@/lib/types/stats/baseball";
+import type { VolleyballStatisticsNode } from "@/lib/types/stats/volleyball";
 import { useTranslations } from "next-intl";
 
 interface GameBoxScoresProps {
@@ -45,6 +47,7 @@ interface GameBoxScoresProps {
   baseballBattingStats?: { node: BaseballBattingStatsNode }[];
   baseballPitchingStats?: { node: BaseballPitchingStatsNode }[];
   baseballFieldingStats?: { node: BaseballFieldingStatsNode }[];
+  volleyballStats?: { node: VolleyballStatisticsNode }[];
 }
 
 interface TeamBoxScoreGroup<T extends BoxScoreNode> {
@@ -112,6 +115,7 @@ export function GameBoxScores({
   baseballBattingStats,
   baseballPitchingStats,
   baseballFieldingStats,
+  volleyballStats,
 }: GameBoxScoresProps) {
   const t = useTranslations();
 
@@ -120,7 +124,8 @@ export function GameBoxScores({
     game.sportType !== SportType.PICKLEBALL &&
     game.sportType !== SportType.TENNIS &&
     game.sportType !== SportType.FOOTBALL &&
-    game.sportType !== SportType.BASEBALL
+    game.sportType !== SportType.BASEBALL &&
+    game.sportType !== SportType.VOLLEYBALL
   ) {
     return null;
   }
@@ -308,6 +313,15 @@ export function GameBoxScores({
       );
     }
 
+    if (game.sportType === SportType.VOLLEYBALL) {
+      return (
+        <VolleyballStatsTable
+          {...sharedProps}
+          boxScores={group.boxScores as { node: VolleyballStatisticsNode }[]}
+        />
+      );
+    }
+
     return (
       <BasketballBoxScoreTable
         {...sharedProps}
@@ -316,12 +330,14 @@ export function GameBoxScores({
     );
   }
 
-  const teamGroups =
-    game.sportType === SportType.PICKLEBALL && pickleballStats
-      ? groupByTeam(game, pickleballStats, fallbackGroupName)
-      : game.sportType === SportType.TENNIS && tennisStats
-        ? groupByTeam(game, tennisStats, fallbackGroupName)
-        : groupByTeam(game, boxScores ?? [], fallbackGroupName);
+  function getStatsForSport(): { node: BoxScoreNode }[] {
+    if (game.sportType === SportType.PICKLEBALL && pickleballStats) return pickleballStats;
+    if (game.sportType === SportType.TENNIS && tennisStats) return tennisStats;
+    if (game.sportType === SportType.VOLLEYBALL && volleyballStats) return volleyballStats;
+    return boxScores ?? [];
+  }
+
+  const teamGroups = groupByTeam(game, getStatsForSport(), fallbackGroupName);
 
   return (
     <div className="space-y-4 [content-visibility:auto] [contain-intrinsic-size:0_200px]">

--- a/src/components/game/game-form-fields.tsx
+++ b/src/components/game/game-form-fields.tsx
@@ -36,6 +36,8 @@ export const createGameFormSchema = z
     winByTwo: z.boolean().optional(),
     scoringType: z.enum(PickleballScoringType).optional(),
     innings: z.number().int().positive("Must be positive").optional(),
+    pointsPerSet: z.number().int().positive("Must be positive").optional(),
+    pointsPerFinalSet: z.number().int().positive("Must be positive").optional(),
     location: locationSchema,
     visibility: z.enum(GameVisibility).default(GameVisibility.PUBLIC),
     statEntryMode: z.enum(StatEntryMode).default(StatEntryMode.OPEN),
@@ -59,6 +61,7 @@ export const createGameFormSchema = z
       if (data.bestOf === undefined) return true;
       if (data.sportType === SportType.TENNIS) return data.bestOf === 3 || data.bestOf === 5;
       if (data.sportType === SportType.PICKLEBALL) return data.bestOf === 1 || data.bestOf === 3 || data.bestOf === 5;
+      if (data.sportType === SportType.VOLLEYBALL) return data.bestOf === 3 || data.bestOf === 5;
       return true;
     },
     {
@@ -78,6 +81,8 @@ export interface CreateGameFormValues {
   winByTwo?: boolean;
   scoringType?: PickleballScoringType;
   innings?: number;
+  pointsPerSet?: number;
+  pointsPerFinalSet?: number;
   location?: LocationValue;
   visibility: GameVisibility;
   statEntryMode: StatEntryMode;
@@ -95,6 +100,8 @@ export const updateGameFormSchema = z.object({
   winByTwo: z.boolean().optional(),
   scoringType: z.enum(PickleballScoringType).optional(),
   innings: z.number().int().positive("Must be positive").optional(),
+  pointsPerSet: z.number().int().positive("Must be positive").optional(),
+  pointsPerFinalSet: z.number().int().positive("Must be positive").optional(),
   location: locationSchema.nullable(),
   visibility: z.enum(GameVisibility).optional(),
   statEntryMode: z.enum(StatEntryMode).optional(),
@@ -109,6 +116,8 @@ export interface UpdateGameFormValues {
   winByTwo?: boolean;
   scoringType?: PickleballScoringType;
   innings?: number;
+  pointsPerSet?: number;
+  pointsPerFinalSet?: number;
   location?: LocationValue | null;
   visibility?: GameVisibility;
   statEntryMode?: StatEntryMode;

--- a/src/components/game/game-score-block.tsx
+++ b/src/components/game/game-score-block.tsx
@@ -11,6 +11,7 @@ import { BasketballScoreForm } from "@/components/game/scoreboard/basketball-sco
 import { FootballScoreForm } from "@/components/game/scoreboard/football-score-form";
 import { PickleballScoreForm } from "@/components/game/scoreboard/pickleball-score-form";
 import { TennisScoreForm } from "@/components/game/scoreboard/tennis-score-form";
+import { VolleyballScoreForm } from "@/components/game/scoreboard/volleyball-score-form";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { GameStatus, SportType } from "@/lib/constants";
@@ -139,6 +140,23 @@ export function GameScoreBlock({ game, statusPill }: GameScoreBlockProps) {
               game.metadata.pickleballBestOf != null
                 ? game.metadata.pickleballBestOf
                 : 3
+            }
+            onSuccess={handleClose}
+            onCancel={handleClose}
+          />
+        );
+      case SportType.VOLLEYBALL:
+        return (
+          <VolleyballScoreForm
+            participantA={participantA}
+            participantB={participantB}
+            nameA={nameA}
+            nameB={nameB}
+            bestOf={
+              game.metadata.__typename === "VolleyballGameMetadata" &&
+              game.metadata.volleyballBestOf != null
+                ? game.metadata.volleyballBestOf
+                : 5
             }
             onSuccess={handleClose}
             onCancel={handleClose}

--- a/src/components/game/live/game-detail-client.tsx
+++ b/src/components/game/live/game-detail-client.tsx
@@ -27,6 +27,7 @@ import type {
   BaseballPitchingStatsNode,
   BaseballFieldingStatsNode,
 } from "@/lib/types/stats/baseball";
+import type { VolleyballStatisticsNode } from "@/lib/types/stats/volleyball";
 import { WifiOff } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
@@ -60,6 +61,7 @@ interface GameDetailClientProps {
   initialBaseballBattingStats?: { node: BaseballBattingStatsNode }[];
   initialBaseballPitchingStats?: { node: BaseballPitchingStatsNode }[];
   initialBaseballFieldingStats?: { node: BaseballFieldingStatsNode }[];
+  initialVolleyballStats?: { node: VolleyballStatisticsNode }[];
   playerId: number | null;
   currentUserId: string | null;
   children: ReactNode;
@@ -76,6 +78,7 @@ export function GameDetailClient({
   initialBaseballBattingStats,
   initialBaseballPitchingStats,
   initialBaseballFieldingStats,
+  initialVolleyballStats,
   playerId,
   currentUserId,
   children,
@@ -236,6 +239,7 @@ export function GameDetailClient({
           baseballBattingStats={initialBaseballBattingStats}
           baseballPitchingStats={initialBaseballPitchingStats}
           baseballFieldingStats={initialBaseballFieldingStats}
+          volleyballStats={initialVolleyballStats}
         />
       </section>
 

--- a/src/components/game/score/game-score.tsx
+++ b/src/components/game/score/game-score.tsx
@@ -1,6 +1,7 @@
 import { PickleballScore } from "@/components/game/score/pickleball-score";
 import { SimpleScore } from "@/components/game/score/simple-score";
 import { TennisScore } from "@/components/game/score/tennis-score";
+import { VolleyballScore } from "@/components/game/score/volleyball-score";
 import { SportType } from "@/lib/constants";
 import type { GameParticipant } from "@/lib/types/game";
 import type { ReactNode } from "react";
@@ -27,6 +28,8 @@ export function GameScore({ sportType, participants, statusPill, size = "sm" }: 
       return <TennisScore participantA={a} participantB={b} statusPill={statusPill} size={size} />;
     case SportType.PICKLEBALL:
       return <PickleballScore participantA={a} participantB={b} statusPill={statusPill} size={size} />;
+    case SportType.VOLLEYBALL:
+      return <VolleyballScore participantA={a} participantB={b} statusPill={statusPill} size={size} />;
     default:
       return null;
   }

--- a/src/components/game/score/volleyball-score.tsx
+++ b/src/components/game/score/volleyball-score.tsx
@@ -1,0 +1,109 @@
+import { AnimatedScore } from "@/components/game/score/animated-score";
+import { getParticipantName } from "@/components/game/score/participant-utils";
+import { cn } from "@/lib/utils";
+import type {
+  GameParticipant,
+  VolleyballParticipantMetadata,
+} from "@/lib/types/game";
+import type { ReactNode } from "react";
+
+function getVolleyballMeta(
+  participant: GameParticipant,
+): VolleyballParticipantMetadata | null {
+  const meta = participant.metadata;
+  return meta?.__typename === "VolleyballParticipantMetadata" ? meta : null;
+}
+
+interface VolleyballScoreProps {
+  participantA: GameParticipant;
+  participantB: GameParticipant;
+  statusPill?: ReactNode;
+  size?: "sm" | "lg";
+}
+
+export function VolleyballScore({
+  participantA,
+  participantB,
+  statusPill,
+  size = "sm",
+}: VolleyballScoreProps) {
+  const metaA = getVolleyballMeta(participantA);
+  const metaB = getVolleyballMeta(participantB);
+  const nameA = getParticipantName(participantA);
+  const nameB = getParticipantName(participantB);
+
+  const setsA = metaA?.setsWon ?? 0;
+  const setsB = metaB?.setsWon ?? 0;
+
+  const aWins = setsA > setsB;
+  const bWins = setsB > setsA;
+
+  const setScores =
+    metaA && metaB && metaA.sets.length > 0
+      ? metaA.sets.map((setA, i) => {
+          const setB = metaB.sets[i];
+          return `${setA.pointsScored}-${setB ? setB.pointsScored : 0}`;
+        })
+      : null;
+
+  const nameClass = size === "lg" ? "text-base sm:text-lg" : "text-sm";
+  const scoreClass = size === "lg" ? "text-5xl sm:text-6xl" : "text-3xl";
+  const pillClass =
+    size === "lg" ? "text-sm px-3 py-1" : "text-xs px-2 py-0.5";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex-1 text-center min-w-0">
+          <p
+            className={cn(
+              "truncate font-semibold font-heading",
+              nameClass,
+            )}
+          >
+            {nameA}
+          </p>
+          <AnimatedScore
+            value={setsA}
+            winning={aWins}
+            scoreClass={scoreClass}
+          />
+        </div>
+
+        {statusPill ? <div className="shrink-0">{statusPill}</div> : null}
+
+        <div className="flex-1 text-center min-w-0">
+          <p
+            className={cn(
+              "truncate font-semibold font-heading",
+              nameClass,
+            )}
+          >
+            {nameB}
+          </p>
+          <AnimatedScore
+            value={setsB}
+            winning={bWins}
+            scoreClass={scoreClass}
+          />
+        </div>
+      </div>
+
+      {setScores ? (
+        <div className="flex items-center justify-center gap-2">
+          {setScores.map((score, i) => (
+            <span
+              key={`set-${i}`}
+              className={cn(
+                "rounded-full bg-muted font-medium text-muted-foreground tabular-nums",
+                pillClass,
+              )}
+            >
+              {score}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/game/scoreboard/volleyball-score-form.tsx
+++ b/src/components/game/scoreboard/volleyball-score-form.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { updateParticipantScores } from "@/app/[locale]/game/participant-actions";
+import { Button } from "@/components/ui/button";
+import { FieldError } from "@/components/ui/field";
+import { toFieldErrors } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  GameParticipantDetail,
+  UpdateParticipantScoreEntry,
+} from "@/lib/types/game";
+import { useForm } from "@tanstack/react-form";
+import { X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+interface VolleyballScoreFormProps {
+  participantA: GameParticipantDetail;
+  participantB: GameParticipantDetail;
+  nameA: string;
+  nameB: string;
+  bestOf: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+const volleyballSetSchema = z.object({
+  pointsScoredA: z
+    .number()
+    .int("Must be a whole number")
+    .min(0, "Must be non-negative"),
+  pointsScoredB: z
+    .number()
+    .int("Must be a whole number")
+    .min(0, "Must be non-negative"),
+});
+
+const createVolleyballScoreSchema = (bestOf: number) =>
+  z.object({
+    sets: z
+      .array(volleyballSetSchema)
+      .min(1, "At least one set required")
+      .max(bestOf, `Cannot exceed ${bestOf} sets`),
+  });
+
+interface VolleyballSet {
+  pointsScoredA: number;
+  pointsScoredB: number;
+}
+
+function extractSets(
+  participantA: GameParticipantDetail,
+  participantB: GameParticipantDetail,
+): VolleyballSet[] {
+  const metaA = participantA.metadata;
+  const metaB = participantB.metadata;
+
+  if (
+    metaA?.__typename === "VolleyballParticipantMetadata" &&
+    metaB?.__typename === "VolleyballParticipantMetadata"
+  ) {
+    return metaA.sets.map((setA, i) => ({
+      pointsScoredA: setA.pointsScored,
+      pointsScoredB: metaB.sets[i]?.pointsScored ?? 0,
+    }));
+  }
+
+  return [];
+}
+
+export function VolleyballScoreForm({
+  participantA,
+  participantB,
+  nameA,
+  nameB,
+  bestOf,
+  onSuccess,
+  onCancel,
+}: VolleyballScoreFormProps) {
+  const t = useTranslations();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const schema = createVolleyballScoreSchema(bestOf);
+  const validate = ({ value }: { value: { sets: VolleyballSet[] } }) => {
+    const result = schema.safeParse(value);
+    if (result.success) return undefined;
+    return result.error.issues.map((issue) => ({
+      message: issue.message,
+      path: issue.path,
+    }));
+  };
+
+  const form = useForm({
+    defaultValues: {
+      sets: extractSets(participantA, participantB),
+    },
+    validators: {
+      onBlur: validate,
+      onSubmit: validate,
+    },
+    onSubmit: async ({ value }) => {
+      setError(null);
+
+      const setsWonA = value.sets.filter(
+        (s) => s.pointsScoredA > s.pointsScoredB,
+      ).length;
+      const setsWonB = value.sets.filter(
+        (s) => s.pointsScoredB > s.pointsScoredA,
+      ).length;
+
+      const isTeam = participantA.__typename === "TeamInstance";
+      const entries: UpdateParticipantScoreEntry[] = [
+        {
+          id: participantA.id,
+          isTeam,
+          metadata: {
+            volleyball: {
+              setsWon: setsWonA,
+              sets: value.sets.map((s) => ({
+                pointsScored: s.pointsScoredA,
+              })),
+            },
+          },
+        },
+        {
+          id: participantB.id,
+          isTeam,
+          metadata: {
+            volleyball: {
+              setsWon: setsWonB,
+              sets: value.sets.map((s) => ({
+                pointsScored: s.pointsScoredB,
+              })),
+            },
+          },
+        },
+      ];
+
+      startTransition(async () => {
+        const result = await updateParticipantScores(entries);
+        if (result.success) {
+          toast.success(t("game.scoreboard.scoreUpdated"));
+          onSuccess();
+        } else {
+          const errorMsg =
+            result.message || t("game.scoreboard.scoreUpdateError");
+          setError(errorMsg);
+          toast.error(errorMsg);
+        }
+      });
+    },
+  });
+
+  function handleAddSet() {
+    const currentSets = form.getFieldValue("sets");
+    form.setFieldValue("sets", [
+      ...currentSets,
+      { pointsScoredA: 0, pointsScoredB: 0 },
+    ]);
+  }
+
+  function handleRemoveSet(index: number) {
+    const currentSets = form.getFieldValue("sets");
+    form.setFieldValue(
+      "sets",
+      currentSets.filter((_, i) => i !== index),
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="space-y-4"
+    >
+      <form.Field name="sets">
+        {(field) => (
+          <>
+            {field.state.value.length === 0 ? (
+              <p className="text-center text-sm text-muted-foreground">
+                {t("game.scoreboard.noScores")}
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[150px]">{t("game.scoreboard.player")}</TableHead>
+                      {field.state.value.map((_, i) => (
+                        <TableHead key={i} className="text-center">
+                          <div className="flex items-center justify-center gap-2">
+                            {t("game.scoreboard.set")} {i + 1}
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleRemoveSet(i)}
+                              disabled={isPending}
+                            >
+                              <X className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell className="font-medium">{nameA}</TableCell>
+                      {field.state.value.map((set, i) => (
+                        <TableCell key={i}>
+                          <Input
+                            type="number"
+                            min={0}
+                            className="w-16"
+                            value={set.pointsScoredA}
+                            onChange={(e) => {
+                              const updated = [...field.state.value];
+                              updated[i] = {
+                                ...updated[i],
+                                pointsScoredA: e.target.value
+                                  ? Number(e.target.value)
+                                  : 0,
+                              };
+                              field.handleChange(updated);
+                            }}
+                            onBlur={field.handleBlur}
+                            disabled={isPending}
+                          />
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                    <TableRow>
+                      <TableCell className="font-medium">{nameB}</TableCell>
+                      {field.state.value.map((set, i) => (
+                        <TableCell key={i}>
+                          <Input
+                            type="number"
+                            min={0}
+                            className="w-16"
+                            value={set.pointsScoredB}
+                            onChange={(e) => {
+                              const updated = [...field.state.value];
+                              updated[i] = {
+                                ...updated[i],
+                                pointsScoredB: e.target.value
+                                  ? Number(e.target.value)
+                                  : 0,
+                              };
+                              field.handleChange(updated);
+                            }}
+                            onBlur={field.handleBlur}
+                            disabled={isPending}
+                          />
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+            {field.state.meta.isTouched && (
+              <FieldError errors={toFieldErrors(field.state.meta.errors)} />
+            )}
+          </>
+        )}
+      </form.Field>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive bg-destructive/10 p-3"
+        >
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <div className="flex justify-between">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleAddSet}
+          disabled={isPending}
+        >
+          {t("game.scoreboard.addSet")}
+        </Button>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isPending}
+          >
+            {t("game.scoreboard.cancel")}
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending
+              ? t("game.scoreboard.saving")
+              : t("game.scoreboard.save")}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/game/sport-icon.tsx
+++ b/src/components/game/sport-icon.tsx
@@ -54,6 +54,16 @@ const sportPaths: Record<SportType, ReactNode> = {
       <circle cx="20" cy="19" r="2" />
     </>
   ),
+  VOLLEYBALL: (
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M6.3 3.8a16.55 16.55 0 0 0 1.9 11.5" />
+      <path d="M20.7 17a12.8 12.8 0 0 0-8.7-5 13.3 13.3 0 0 1 0-10" />
+      <path d="M22 11.1c-.8-.6-1.7-1.3-2.6-1.8-3-1.7-6.1-2.5-8.3-2.2" />
+      <path d="M7.8 21.1c1-.4 1.9-.8 2.9-1.4 3-1.7 5.2-4 6.1-6.1" />
+      <path d="M12 12a12.6 12.6 0 0 1-8.7 5" />
+    </>
+  ),
 };
 
 interface SportIconProps {

--- a/src/components/game/update-game-form.tsx
+++ b/src/components/game/update-game-form.tsx
@@ -69,12 +69,15 @@ function buildDefaultValues(
 
   const isTennis = metadata.__typename === "TennisGameMetadata";
   const isPickleball = metadata.__typename === "PickleballGameMetadata";
+  const isVolleyball = metadata.__typename === "VolleyballGameMetadata";
 
   let bestOf: number | undefined;
   if (isTennis) {
     bestOf = metadata.tennisBestOf;
   } else if (isPickleball) {
     bestOf = metadata.pickleballBestOf ?? undefined;
+  } else if (isVolleyball) {
+    bestOf = metadata.volleyballBestOf ?? undefined;
   }
 
   return {
@@ -89,13 +92,19 @@ function buildDefaultValues(
     pointsPerGame: isPickleball
       ? (metadata.pointsPerGame ?? undefined)
       : (undefined as number | undefined),
-    winByTwo: isPickleball
+    winByTwo: isPickleball || isVolleyball
       ? (metadata.winByTwo ?? undefined)
       : (undefined as boolean | undefined),
     scoringType: isPickleball
       ? (metadata.scoringType ?? undefined)
       : (undefined as PickleballScoringType | undefined),
     innings: isBaseball ? (metadata.innings ?? undefined) : (undefined as number | undefined),
+    pointsPerSet: isVolleyball
+      ? (metadata.pointsPerSet ?? undefined)
+      : (undefined as number | undefined),
+    pointsPerFinalSet: isVolleyball
+      ? (metadata.pointsPerFinalSet ?? undefined)
+      : (undefined as number | undefined),
     location: (currentLocation
       ? locationToValue(currentLocation)
       : undefined) as LocationValue | null | undefined,
@@ -150,6 +159,8 @@ export function UpdateGameForm({
           originalBestOf = metadata.tennisBestOf;
         } else if (metadata.__typename === "PickleballGameMetadata") {
           originalBestOf = metadata.pickleballBestOf;
+        } else if (metadata.__typename === "VolleyballGameMetadata") {
+          originalBestOf = metadata.volleyballBestOf;
         }
         const originalTiebreakFinalSet =
           metadata.__typename === "TennisGameMetadata"
@@ -160,8 +171,17 @@ export function UpdateGameForm({
             ? metadata.pointsPerGame
             : null;
         const originalWinByTwo =
-          metadata.__typename === "PickleballGameMetadata"
+          metadata.__typename === "PickleballGameMetadata" ||
+          metadata.__typename === "VolleyballGameMetadata"
             ? metadata.winByTwo
+            : null;
+        const originalPointsPerSet =
+          metadata.__typename === "VolleyballGameMetadata"
+            ? metadata.pointsPerSet
+            : null;
+        const originalPointsPerFinalSet =
+          metadata.__typename === "VolleyballGameMetadata"
+            ? metadata.pointsPerFinalSet
             : null;
         const originalScoringType =
           metadata.__typename === "PickleballGameMetadata"
@@ -181,6 +201,8 @@ export function UpdateGameForm({
         const winByTwoChanged = value.winByTwo !== originalWinByTwo;
         const scoringTypeChanged = value.scoringType !== originalScoringType;
         const inningsChanged = value.innings !== originalInnings;
+        const pointsPerSetChanged = value.pointsPerSet !== originalPointsPerSet;
+        const pointsPerFinalSetChanged = value.pointsPerFinalSet !== originalPointsPerFinalSet;
 
         if (
           periodsChanged ||
@@ -189,7 +211,9 @@ export function UpdateGameForm({
           pointsPerGameChanged ||
           winByTwoChanged ||
           scoringTypeChanged ||
-          inningsChanged
+          inningsChanged ||
+          pointsPerSetChanged ||
+          pointsPerFinalSetChanged
         ) {
           input.metadata = {};
 
@@ -224,6 +248,20 @@ export function UpdateGameForm({
             }
             if (scoringTypeChanged && value.scoringType !== undefined) {
               input.metadata.pickleball.scoringType = value.scoringType;
+            }
+          } else if (sportType === SportType.VOLLEYBALL) {
+            input.metadata.volleyball = {};
+            if (bestOfChanged && value.bestOf !== undefined) {
+              input.metadata.volleyball.bestOf = value.bestOf;
+            }
+            if (pointsPerSetChanged && value.pointsPerSet !== undefined) {
+              input.metadata.volleyball.pointsPerSet = value.pointsPerSet;
+            }
+            if (pointsPerFinalSetChanged && value.pointsPerFinalSet !== undefined) {
+              input.metadata.volleyball.pointsPerFinalSet = value.pointsPerFinalSet;
+            }
+            if (winByTwoChanged && value.winByTwo !== undefined) {
+              input.metadata.volleyball.winByTwo = value.winByTwo;
             }
           } else if (sportType === SportType.BASEBALL) {
             input.metadata.baseball = {};
@@ -535,6 +573,81 @@ export function UpdateGameForm({
                       />
                     )}
                   </Field>
+                )}
+              </form.Field>
+              <form.Field name="winByTwo">
+                {(field) => (
+                  <FormSwitchField
+                    field={field}
+                    label={t("game.form.winByTwo")}
+                    disabled={isPending}
+                  />
+                )}
+              </form.Field>
+            </>
+          )}
+
+          {sportType === SportType.VOLLEYBALL && (
+            <>
+              <form.Field name="bestOf">
+                {(field) => (
+                  <Field
+                    data-invalid={
+                      field.state.meta.isTouched &&
+                      field.state.meta.errors.length > 0
+                        ? true
+                        : undefined
+                    }
+                  >
+                    <FieldLabel htmlFor={field.name}>
+                      {t("game.form.bestOf")}
+                    </FieldLabel>
+                    <Select
+                      value={field.state.value?.toString() ?? null}
+                      onValueChange={(v) => {
+                        field.handleChange(Number(v));
+                        field.handleBlur();
+                      }}
+                      disabled={isPending}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue
+                          placeholder={t("game.form.bestOfPlaceholder")}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="3">3</SelectItem>
+                        <SelectItem value="5">5</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {field.state.meta.isTouched && (
+                      <FieldError
+                        errors={toFieldErrors(field.state.meta.errors)}
+                      />
+                    )}
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="pointsPerSet">
+                {(field) => (
+                  <FormTextField
+                    field={field}
+                    label={t("game.form.pointsPerSet")}
+                    type="number"
+                    disabled={isPending}
+                    placeholder={t("game.form.pointsPerSetPlaceholder")}
+                  />
+                )}
+              </form.Field>
+              <form.Field name="pointsPerFinalSet">
+                {(field) => (
+                  <FormTextField
+                    field={field}
+                    label={t("game.form.pointsPerFinalSet")}
+                    type="number"
+                    disabled={isPending}
+                    placeholder={t("game.form.pointsPerFinalSetPlaceholder")}
+                  />
                 )}
               </form.Field>
               <form.Field name="winByTwo">

--- a/src/components/game/volleyball-stats-form.tsx
+++ b/src/components/game/volleyball-stats-form.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { saveVolleyballStatistics } from "@/app/[locale]/game/volleyball-stats-actions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FieldGroup } from "@/components/ui/field";
+import { FormTextField } from "@/components/ui/form-field";
+import type {
+  VolleyballStatisticsNode,
+  SaveVolleyballStatisticsInput,
+} from "@/lib/types/stats/volleyball";
+import { nullToUndefined, undefinedToNull } from "@/lib/utils";
+import { useForm } from "@tanstack/react-form";
+import { useTranslations } from "next-intl";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+const STAT_FIELDS = [
+  "kills",
+  "attackErrors",
+  "attackAttempts",
+  "aces",
+  "serviceErrors",
+  "blocks",
+  "blockErrors",
+  "digs",
+  "receptionErrors",
+  "assists",
+] as const;
+
+type StatField = (typeof STAT_FIELDS)[number];
+
+interface VolleyballStatsFormProps {
+  gameId: number;
+  initialData: VolleyballStatisticsNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function buildDefaultValues(
+  data: VolleyballStatisticsNode,
+): Record<StatField, number | undefined> {
+  const result = {} as Record<StatField, number | undefined>;
+  for (const field of STAT_FIELDS) {
+    result[field] = nullToUndefined(data[field]);
+  }
+  return result;
+}
+
+function buildInput(
+  value: Record<StatField, number | undefined>,
+  playerId: number,
+  gameId: number,
+): SaveVolleyballStatisticsInput {
+  const input: SaveVolleyballStatisticsInput = { playerId, gameId };
+  for (const field of STAT_FIELDS) {
+    input[field] = undefinedToNull(value[field]);
+  }
+  return input;
+}
+
+export function VolleyballStatsForm({
+  gameId,
+  initialData,
+  open,
+  onOpenChange,
+}: VolleyballStatsFormProps) {
+  const t = useTranslations();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: buildDefaultValues(initialData),
+    onSubmit: async ({ value }) => {
+      setError(null);
+
+      startTransition(async () => {
+        const input = buildInput(value, initialData.player.id, gameId);
+        const result = await saveVolleyballStatistics(input);
+
+        if (result.success) {
+          toast.success(t("game.success.boxScoresSaved"));
+          onOpenChange(false);
+        } else {
+          setError(result.message || t("game.errors.boxScoreError"));
+          toast.error(result.message || t("game.errors.boxScoreError"));
+        }
+      });
+    },
+  });
+
+  const playerName = initialData.player.user.displayName;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {t("game.boxScore.editBoxScores")} - {playerName}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="space-y-4"
+        >
+          <FieldGroup className="sm:grid sm:grid-cols-2">
+            {STAT_FIELDS.map((field) => (
+              <form.Field key={field} name={field}>
+                {(fieldApi) => (
+                  <FormTextField
+                    field={fieldApi}
+                    label={t(`game.boxScore.volleyball.${field}`)}
+                    type="number"
+                    disabled={isPending}
+                    placeholder="0"
+                  />
+                )}
+              </form.Field>
+            ))}
+          </FieldGroup>
+
+          {error && (
+            <div className="rounded-md border border-destructive bg-destructive/10 p-3">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+              {t("actions.cancel")}
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? t("game.actions.saving") : t("actions.save")}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/game/volleyball-stats-table.tsx
+++ b/src/components/game/volleyball-stats-table.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { saveVolleyballStatistics } from "@/app/[locale]/game/volleyball-stats-actions";
+import { PlayerAvatar } from "@/components/game/player-avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Empty, EmptyDescription, EmptyHeader } from "@/components/ui/empty";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { GameStatus, type GameRole } from "@/lib/constants";
+import type { PlayerRef } from "@/lib/types/game";
+import type { VolleyballStatisticsNode } from "@/lib/types/stats/volleyball";
+import { cn } from "@/lib/utils";
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type SortingState,
+} from "@tanstack/react-table";
+import { ArrowUpDown, Pencil } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { type ReactNode, useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { VolleyballStatsForm } from "./volleyball-stats-form";
+
+const STICKY_FIRST_COL =
+  "sticky left-0 z-10 bg-card group-hover/row:bg-muted/50 min-w-[140px]";
+
+const HIGHLIGHTABLE_STATS = [
+  "kills",
+  "aces",
+  "blocks",
+  "digs",
+  "assists",
+  "points",
+] as const;
+
+type HighlightableStat = (typeof HIGHLIGHTABLE_STATS)[number];
+
+interface VolleyballStatsTableProps {
+  gameId: number;
+  teamName: string;
+  boxScores: { node: VolleyballStatisticsNode }[];
+  gameStatus: GameStatus;
+  availablePlayers?: PlayerRef[];
+  viewerGameRole: GameRole | null;
+}
+
+function computeMaxStats(
+  data: VolleyballStatisticsNode[],
+): Record<HighlightableStat, number | null> {
+  const result = {} as Record<HighlightableStat, number | null>;
+
+  for (const stat of HIGHLIGHTABLE_STATS) {
+    let max: number | null = null;
+    for (const row of data) {
+      const value = row[stat];
+      if (value != null && (max === null || value > max)) {
+        max = value;
+      }
+    }
+    result[stat] = max;
+  }
+
+  return result;
+}
+
+export function VolleyballStatsTable({
+  gameId,
+  teamName,
+  boxScores,
+  gameStatus,
+  availablePlayers = [],
+  viewerGameRole,
+}: VolleyballStatsTableProps) {
+  const t = useTranslations("game.boxScore.volleyball");
+  const boxScoreT = useTranslations("game.boxScore");
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "points", desc: true },
+  ]);
+  const [editingStat, setEditingStat] =
+    useState<VolleyballStatisticsNode | null>(null);
+  const [selectedPlayerId, setSelectedPlayerId] = useState<string>("");
+  const [isPending, startTransition] = useTransition();
+
+  const canEdit =
+    viewerGameRole != null &&
+    (gameStatus === GameStatus.IN_PROGRESS || gameStatus === GameStatus.COMPLETE);
+
+  const existingPlayerIds = useMemo(
+    () => new Set(boxScores.map((edge) => edge.node.player.id)),
+    [boxScores],
+  );
+
+  const playersWithoutStats = useMemo(
+    () => availablePlayers.filter((p) => !existingPlayerIds.has(p.id)),
+    [availablePlayers, existingPlayerIds],
+  );
+
+  function handleAddPlayerStats() {
+    if (!selectedPlayerId) return;
+    startTransition(async () => {
+      const result = await saveVolleyballStatistics({
+        playerId: Number(selectedPlayerId),
+        gameId,
+      });
+      if (result.success) {
+        toast.success(boxScoreT("playerStatsAdded"));
+        setSelectedPlayerId("");
+      } else {
+        toast.error(result.message ?? boxScoreT("playerStatsError"));
+      }
+    });
+  }
+
+  const data = useMemo(() => boxScores.map((edge) => edge.node), [boxScores]);
+
+  const maxStats = useMemo(() => computeMaxStats(data), [data]);
+
+  const columns: ColumnDef<VolleyballStatisticsNode>[] = useMemo(() => {
+    function statCellClass(
+      stat: HighlightableStat,
+      value: number | null,
+    ): string {
+      if (
+        data.length >= 2 &&
+        value != null &&
+        maxStats[stat] != null &&
+        value === maxStats[stat]
+      ) {
+        return "text-primary font-semibold";
+      }
+      return "";
+    }
+
+    function sortableHeader(
+      label: string,
+      column: { toggleSorting: (asc: boolean) => void; getIsSorted: () => false | "asc" | "desc" },
+    ): ReactNode {
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          className="h-8 px-2"
+        >
+          {label}
+          <ArrowUpDown className="ml-1 h-3 w-3" />
+        </Button>
+      );
+    }
+
+    function highlightableStatColumn(
+      stat: HighlightableStat,
+    ): ColumnDef<VolleyballStatisticsNode> {
+      return {
+        accessorKey: stat,
+        header: ({ column }) => sortableHeader(t(stat), column),
+        cell: ({ row }) => {
+          const value = row.original[stat];
+          return (
+            <span className={cn("tabular-nums", statCellClass(stat, value))}>
+              {value ?? "-"}
+            </span>
+          );
+        },
+      };
+    }
+
+    function plainStatColumn(
+      key: keyof VolleyballStatisticsNode & string,
+    ): ColumnDef<VolleyballStatisticsNode> {
+      return {
+        accessorKey: key,
+        header: t(key),
+        cell: ({ row }) => (
+          <span className="tabular-nums">
+            {(row.original[key] as number | null) ?? "-"}
+          </span>
+        ),
+      };
+    }
+
+    return [
+      {
+        accessorKey: "player",
+        header: boxScoreT("player"),
+        cell: ({ row }) => {
+          const player = row.original.player;
+          return (
+            <div className="flex items-center gap-2">
+              <PlayerAvatar player={player} size="sm" loading="lazy" />
+              <span className="truncate">{player.user.displayName}</span>
+            </div>
+          );
+        },
+        enableSorting: false,
+      },
+      ...HIGHLIGHTABLE_STATS.map(highlightableStatColumn),
+      plainStatColumn("attackErrors"),
+      plainStatColumn("attackAttempts"),
+      {
+        id: "hittingPercentage",
+        header: t("hittingPercentage"),
+        cell: ({ row }) => {
+          const kills = row.original.kills;
+          const errors = row.original.attackErrors;
+          const attempts = row.original.attackAttempts;
+          if (kills == null || errors == null || attempts == null || attempts === 0) {
+            return <span className="tabular-nums">-</span>;
+          }
+          return (
+            <span className="tabular-nums">
+              {((kills - errors) / attempts).toFixed(3)}
+            </span>
+          );
+        },
+      },
+      plainStatColumn("serviceErrors"),
+      plainStatColumn("blockErrors"),
+      plainStatColumn("receptionErrors"),
+      ...(canEdit
+        ? [
+            {
+              id: "actions",
+              header: "",
+              cell: ({
+                row,
+              }: {
+                row: { original: VolleyballStatisticsNode };
+              }) => (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setEditingStat(row.original)}
+                >
+                  <Pencil className="h-4 w-4" />
+                  <span className="sr-only">Edit</span>
+                </Button>
+              ),
+            },
+          ]
+        : []),
+    ];
+  }, [t, boxScoreT, canEdit, maxStats, data.length]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    state: { sorting },
+  });
+
+  const addPlayerControls = canEdit && playersWithoutStats.length > 0 && (
+    <div className="flex items-center gap-2">
+      <Select
+        value={selectedPlayerId || null}
+        onValueChange={(val) => setSelectedPlayerId(val ?? "")}
+        items={playersWithoutStats.map((p) => ({ value: String(p.id), label: p.user.displayName }))}
+      >
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder={boxScoreT("selectPlayer")} />
+        </SelectTrigger>
+        <SelectContent>
+          {playersWithoutStats.map((player) => (
+            <SelectItem key={player.id} value={String(player.id)}>
+              {player.user.displayName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        size="sm"
+        onClick={handleAddPlayerStats}
+        disabled={!selectedPlayerId || isPending}
+      >
+        {boxScoreT("addPlayerStats")}
+      </Button>
+    </div>
+  );
+
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle>{teamName}</CardTitle>
+          {addPlayerControls}
+        </CardHeader>
+        <CardContent>
+          <Empty className="border-none">
+            <EmptyHeader>
+              <EmptyDescription>{boxScoreT("noBoxScores")}</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle>{teamName}</CardTitle>
+        {addPlayerControls}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header, index) => (
+                    <TableHead
+                      key={header.id}
+                      className={cn(
+                        index === 0 && STICKY_FIRST_COL,
+                      )}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} className="group/row">
+                  {row.getVisibleCells().map((cell, index) => (
+                    <TableCell
+                      key={cell.id}
+                      className={cn(
+                        index === 0 && STICKY_FIRST_COL,
+                      )}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+
+        {editingStat && (
+          <VolleyballStatsForm
+            gameId={gameId}
+            initialData={editingStat}
+            open={true}
+            onOpenChange={(open) => !open && setEditingStat(null)}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,6 +33,8 @@ export enum SportFormat {
   AMERICAN_FOOTBALL = "AMERICAN_FOOTBALL",
   SINGLES = "SINGLES",
   DOUBLES = "DOUBLES",
+  INDOOR = "INDOOR",
+  BEACH = "BEACH",
 }
 
 /**
@@ -67,6 +69,15 @@ export const SportFormatConfig = {
     maxTeamSize: 2,
     maxParticipants: 2,
   },
+  INDOOR: {
+    participation: ParticipationType.TEAM,
+    maxParticipants: 2,
+  },
+  BEACH: {
+    participation: ParticipationType.TEAM,
+    maxTeamSize: 2,
+    maxParticipants: 2,
+  },
 } as const;
 
 export enum SportType {
@@ -75,6 +86,7 @@ export enum SportType {
   FOOTBALL = "FOOTBALL",
   TENNIS = "TENNIS",
   PICKLEBALL = "PICKLEBALL",
+  VOLLEYBALL = "VOLLEYBALL",
 }
 
 export enum PickleballScoringType {
@@ -126,8 +138,14 @@ export const SportTypeConfig = {
     accentClass: "bg-sport-pickleball-foreground",
     gradientClass: "bg-sport-pickleball/5 dark:bg-sport-pickleball/15",
   },
-  //   SOFTBALL: [],
-  //   SWIM: [],
+  VOLLEYBALL: {
+    formats: [SportFormat.INDOOR, SportFormat.BEACH],
+    icon: "/sports/volleyball.svg",
+    bgClass: "bg-sport-volleyball",
+    fgClass: "text-sport-volleyball-foreground",
+    accentClass: "bg-sport-volleyball-foreground",
+    gradientClass: "bg-sport-volleyball/5 dark:bg-sport-volleyball/15",
+  },
 } as const;
 
 export function getFormats(sport: SportType) {
@@ -260,7 +278,8 @@ export function getFormatFromMetadata(
     | { __typename: "BasketballGameMetadata"; basketballFormat: string }
     | { __typename: "TennisGameMetadata"; tennisFormat: string }
     | { __typename: "FootballGameMetadata"; footballFormat: string }
-    | { __typename: "PickleballGameMetadata"; pickleballFormat: string },
+    | { __typename: "PickleballGameMetadata"; pickleballFormat: string }
+    | { __typename: "VolleyballGameMetadata"; volleyballFormat: string },
 ): SportFormat | null {
   switch (metadata.__typename) {
     case "BaseballGameMetadata":
@@ -273,6 +292,8 @@ export function getFormatFromMetadata(
       return metadata.footballFormat as SportFormat;
     case "PickleballGameMetadata":
       return metadata.pickleballFormat as SportFormat;
+    case "VolleyballGameMetadata":
+      return metadata.volleyballFormat as SportFormat;
   }
 }
 

--- a/src/lib/graphql-fragments.ts
+++ b/src/lib/graphql-fragments.ts
@@ -267,6 +267,18 @@ export const gameMetadataFragment = {
       winByTwo: true,
       scoringType: true,
     },
+    {
+      __typeName: "VolleyballGameMetadata",
+      volleyballFormat: {
+        __aliasFor: "format",
+      },
+      volleyballBestOf: {
+        __aliasFor: "bestOf",
+      },
+      pointsPerSet: true,
+      pointsPerFinalSet: true,
+      winByTwo: true,
+    },
   ],
 };
 
@@ -298,6 +310,11 @@ export const participantMetadataFragment = {
       __typeName: "PickleballParticipantMetadata",
       gamesWon: true,
       games: { pointsScored: true },
+    },
+    {
+      __typeName: "VolleyballParticipantMetadata",
+      setsWon: true,
+      sets: { pointsScored: true },
     },
   ],
 };

--- a/src/lib/types/game.ts
+++ b/src/lib/types/game.ts
@@ -90,12 +90,22 @@ export interface PickleballGameMetadata {
   scoringType: PickleballScoringType | null;
 }
 
+export interface VolleyballGameMetadata {
+  __typename: "VolleyballGameMetadata";
+  volleyballFormat: SportFormat.INDOOR | SportFormat.BEACH;
+  volleyballBestOf: number | null;
+  pointsPerSet: number | null;
+  pointsPerFinalSet: number | null;
+  winByTwo: boolean | null;
+}
+
 export type GameMetadata =
   | BaseballGameMetadata
   | BasketballGameMetadata
   | TennisGameMetadata
   | FootballGameMetadata
-  | PickleballGameMetadata;
+  | PickleballGameMetadata
+  | VolleyballGameMetadata;
 
 // ---------- Participant Metadata (response types) ----------
 
@@ -130,12 +140,23 @@ export interface PickleballParticipantMetadata {
   games: PickleballGameScore[];
 }
 
+export interface VolleyballSetScore {
+  pointsScored: number;
+}
+
+export interface VolleyballParticipantMetadata {
+  __typename: "VolleyballParticipantMetadata";
+  setsWon: number;
+  sets: VolleyballSetScore[];
+}
+
 export type ParticipantMetadata =
   | BaseballParticipantMetadata
   | BasketballParticipantMetadata
   | TennisParticipantMetadata
   | FootballParticipantMetadata
-  | PickleballParticipantMetadata;
+  | PickleballParticipantMetadata
+  | VolleyballParticipantMetadata;
 
 /**
  * Team instance participant in a game (basic info)
@@ -400,6 +421,37 @@ export interface CreatePickleballGameInput {
 }
 
 /**
+ * Input for creating a volleyball game
+ */
+export interface CreateVolleyballGameInput {
+  sportType: SportType.VOLLEYBALL;
+  startDate: string;
+  description?: string;
+  location?: {
+    address: {
+      street?: string;
+      city: string;
+      state?: string;
+      postalCode?: string;
+      country: string;
+    };
+    coordinates?: {
+      latitude: number;
+      longitude: number;
+    };
+  };
+  visibility?: GameVisibility;
+  statEntryMode?: StatEntryMode;
+  metadata: {
+    format: SportFormat.INDOOR | SportFormat.BEACH;
+    bestOf?: number;
+    pointsPerSet?: number;
+    pointsPerFinalSet?: number;
+    winByTwo?: boolean;
+  };
+}
+
+/**
  * Union type for creating a game
  */
 export type CreateGameInput =
@@ -407,7 +459,8 @@ export type CreateGameInput =
   | CreateBasketballGameInput
   | CreateTennisGameInput
   | CreateFootballGameInput
-  | CreatePickleballGameInput;
+  | CreatePickleballGameInput
+  | CreateVolleyballGameInput;
 
 /**
  * Input for updating a game
@@ -459,6 +512,13 @@ export interface UpdateGameInput {
       winByTwo?: boolean;
       scoringType?: PickleballScoringType;
     };
+    volleyball?: {
+      format?: SportFormat.INDOOR | SportFormat.BEACH;
+      bestOf?: number;
+      pointsPerSet?: number;
+      pointsPerFinalSet?: number;
+      winByTwo?: boolean;
+    };
   };
   visibility?: GameVisibility;
   statEntryMode?: StatEntryMode;
@@ -495,6 +555,10 @@ export interface ParticipantMetadataInput {
   pickleball?: {
     gamesWon: number;
     games: { pointsScored: number }[];
+  };
+  volleyball?: {
+    setsWon: number;
+    sets: { pointsScored: number }[];
   };
 }
 

--- a/src/lib/types/stats/volleyball.ts
+++ b/src/lib/types/stats/volleyball.ts
@@ -1,0 +1,56 @@
+import type { BoxScoreNode, SaveBoxScoreInput } from "./base";
+
+/**
+ * Volleyball statistics entry returned from the server.
+ */
+export interface VolleyballStatisticsNode extends BoxScoreNode {
+  kills: number | null;
+  attackErrors: number | null;
+  attackAttempts: number | null;
+  aces: number | null;
+  serviceErrors: number | null;
+  blocks: number | null;
+  blockErrors: number | null;
+  digs: number | null;
+  receptionErrors: number | null;
+  assists: number | null;
+  points: number | null;
+}
+
+/**
+ * Input for saving volleyball statistics.
+ * Patch semantics:
+ * - Omit a field (undefined) to leave it unchanged
+ * - Set to null to clear the value
+ * - Set to a number to update
+ */
+export interface SaveVolleyballStatisticsInput extends SaveBoxScoreInput {
+  kills?: number | null;
+  attackErrors?: number | null;
+  attackAttempts?: number | null;
+  aces?: number | null;
+  serviceErrors?: number | null;
+  blocks?: number | null;
+  blockErrors?: number | null;
+  digs?: number | null;
+  receptionErrors?: number | null;
+  assists?: number | null;
+}
+
+/**
+ * Per-player statistics data for bulk save (gameId is at parent level).
+ * Independent interface mirroring schema -- not derived from SaveVolleyballStatisticsInput.
+ */
+export interface SaveVolleyballStatisticsData {
+  playerId: number;
+  kills?: number | null;
+  attackErrors?: number | null;
+  attackAttempts?: number | null;
+  aces?: number | null;
+  serviceErrors?: number | null;
+  blocks?: number | null;
+  blockErrors?: number | null;
+  digs?: number | null;
+  receptionErrors?: number | null;
+  assists?: number | null;
+}


### PR DESCRIPTION
## Summary

- Add full volleyball support: Indoor and Beach formats with set-based scoring (setsWon + per-set points)
- Teal/cyan theme (hue 185), SVG icon, translations, CSS variables for light/dark mode
- Game create/update forms with bestOf, pointsPerSet, pointsPerFinalSet, winByTwo options
- Box score stats: kills, attack errors/attempts, aces, service errors, blocks, block errors, digs, reception errors, assists, plus computed hitting percentage and server-computed points
- Score display, score editing form, stats table with leader highlighting, stats edit dialog, server actions (single + bulk save)
- Wired into game detail page, client wrapper, and box score orchestrator

## Test plan

- [x] `npm run build` passes (TypeScript catches missing `Record<SportType, ...>` entries)
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 710 tests pass (49 files)
- [x] Sport badge test updated for VOLLEYBALL
- [x] Volleyball score display component tested (5 tests)
- [x] Game score block test added for volleyball form toggle
- [ ] Manual: create a volleyball game (Indoor + Beach), verify form fields
- [ ] Manual: enter set scores, verify display
- [ ] Manual: add box score stats, verify table rendering and hitting % calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)