### PR TITLE
Revamp chat on shadcn native chat components

### DIFF
--- a/.claudedoc/chat-shadcn-revamp/design.md
+++ b/.claudedoc/chat-shadcn-revamp/design.md
@@ -1,0 +1,933 @@
+# Chat Revamp — Technical Design
+
+Design owner: principal engineer (design agent).
+Source of truth for behavior: `.claudedoc/chat-shadcn-revamp/requirements.md` (final, adversarially
+reviewed). This document decides **how** it is built; it does not reopen product decisions.
+
+This is a single-PR effort that rewrites the chat front-of-house onto the five installed shadcn chat
+primitives, adds day separators and media captions, and hardens real-time behavior. No backend schema
+changes: `SendMediaChatMessageInput` already accepts `caption` and `replyToId`; day separators derive
+from existing timestamps.
+
+> Revision note: this version incorporates the adversarial review (1 blocker + 7 should-fix + nits).
+> The most consequential change is that **day separators are never standalone Content children** — they
+> render *inside* the first `MessageScrollerItem` of each day — because the primitive's prepend-restore
+> path only fires when the previous first child moves to index > 0. See §1.1, §3, §10.
+
+---
+
+## 0. Key architectural decisions (summary)
+
+1. **The message thread runs on `MessageScroller`** (`src/components/ui/message-scroller.tsx`),
+   replacing the hand-rolled `ScrollArea` + `IntersectionObserver` + manual scroll-preservation in
+   `message-list.tsx`. Provider config: `autoScroll`, `defaultScrollPosition="end"`,
+   `scrollEdgeThreshold={100}`. The primitive's `role=region`/`role=log` and jump-to-latest button come
+   for free (see §7).
+2. **Message rows use `Message` + `Bubble` anatomy**; **file chips use `Attachment`**; **image/video stay
+   bespoke** inside `BubbleContent`; **day separators render as a `Marker` inside the first item of each
+   day**; **system notices use a centered `Marker`** (visually distinct from day separators on purpose).
+3. **Thread structure (separators + grouping) is derived by pure functions** in a new
+   `chat-thread-utils.ts`, unit-tested under a pinned timezone.
+4. **The composer is a single coexistence state machine**: reply preview + attachment preview +
+   caption/text field are always independently present; one `content` field doubles as text and caption;
+   the whole composer disables while a send is in flight.
+5. **Real-time is hardened in `conversation-view.tsx`**: reconnect reconciles into the existing thread
+   without unmounting the composer or force-scrolling (with an honest reset when a >25-message gap is
+   detected); a shared editor-abandon helper fires on remote edit/delete *and* on reconcile; deleted
+   originals propagate into reply snippets; jump-to-original surfaces a "not loaded" notice.
+6. **DM send-failure recovery**: the attempted text/caption is restated in the error toast before the
+   composer is replaced by the banner.
+7. **Two client-only contract touches**: `replyTo { deletedDate }` selection (authoritative deleted-reply
+   snippets on load) and `sendMediaMessage` passing caption + replyToId.
+
+---
+
+## 1. Component-by-component mapping
+
+Directory: `src/components/chat/`. Legend: **Rewrite** · **Restyle** · **Light** · **New** · **Delete**.
+
+| File | Disposition | Notes |
+| --- | --- | --- |
+| `message-list.tsx` | **Rewrite** | `MessageScroller`; day separators + grouping via `buildThreadItems`; edge-triggered load-older with an **overlay** loading indicator (no Content sentinel child); jump-to-latest = primitive `MessageScrollerButton`. All existing `ScrollArea`/`IntersectionObserver`/scroll-preservation/`showNewMessageIndicator` code is removed. |
+| `message-bubble.tsx` | **Rewrite** | `Message` + `MessageAvatar` + `MessageContent` + `MessageHeader`/`MessageFooter` + `Bubble`/`BubbleContent`. Own vs. others via `Bubble variant` + `align`. |
+| `system-message-bubble.tsx` | **Rewrite** | Centered `Marker` (default variant, no flanking lines) — deliberately distinct from day separators. |
+| `message-input.tsx` | **Rewrite** | Composer coexistence state machine (§2). |
+| `chat-attachment-preview.tsx` | **Rewrite** | `Attachment` primitive anatomy. |
+| `reply-preview.tsx` | **Restyle** | Reused as composer reply preview + in-bubble reply quote; typography components; keyboard-reachable jump button; ≥44px dismiss. |
+| `chat-attachment-menu.tsx` | **Light** | Fix touch target to ≥44×44 (§7). |
+| `message-actions-menu.tsx` | **Light** | Trigger ≥44px touch target on mobile; keep dropdown + labels. |
+| `conversation-header.tsx` | **Restyle** | Adopt look; back/members icon buttons ≥44px on mobile. |
+| `conversation-view.tsx` | **Rewrite (logic)** | Reconnect reconcile + gap reset, editor-abandon helper, new `onSendMedia` signature, jump-to-original notice, localized loading string (§5, §6). |
+| `chat-room-list.tsx` | **Restyle** | Localize the room-list "Loading…"; keep `ScrollArea` + infinite scroll; adopt look. |
+| `chat-room-list-item.tsx` | **Restyle** | Preview/unread logic unchanged; adopt look; typography. |
+| `member-list-panel.tsx` | **Restyle** | Member name → `displayName`; joined date → `useFormatter().dateTime` (app locale); badge/look. |
+| `create-chat-room-dialog.tsx` / `mutual-follow-selector.tsx` | **Light** | Already shadcn; adopt restyle; no flow change. |
+| `delete-message-dialog.tsx` / `remove-member-dialog.tsx` | **Light** | Already `AlertDialog`; adopt restyle. |
+| `chat-layout.tsx` | **Light** | Two-pane / mobile single-pane unchanged. |
+| `message-button.tsx` | **Unchanged** | Profile "Message" CTA. |
+| `dm-disabled-banner.tsx` | **Light** | Unchanged behavior (recovery handled by toast, §6). |
+| `chat-utils.ts` | **Light** | Keep `formatMessageTime`, `formatRelativeTime`, `getChatRoomDisplayName`, `shouldShowSender` (reused by `buildThreadItems`). |
+| `message-preview-utils.ts` | **Light** | `getReplyPreviewContent` gains a deleted-first check (§1.3, §5.3). |
+| `chat-thread-utils.ts` | **New** | Pure derivation (§3). |
+| `day-separator.tsx` | **New** | Renders a `Marker` with the localized label from `classifyDayLabel` + `useFormatter` (§3.4). |
+
+**Deleted files: none.** `chat.newMessages` i18n key becomes orphaned by the jump-to-latest button and
+is removed in the same PR.
+
+### 1.1 New thread render tree (`message-list.tsx`)
+
+Hooks must be called **inside** the provider (hard-won: they throw outside it), so the list is
+`Provider > Root > MessageListInner`.
+
+```
+<MessageScrollerProvider
+  autoScroll
+  defaultScrollPosition="end"
+  scrollEdgeThreshold={100}                         {/* restores the old 100px near-bottom follow window */}
+>
+  <MessageScroller className="flex-1">              {/* root is relative + size-full min-h-0 flex-col */}
+    <MessageScrollerViewport ref={viewportRef} aria-label={t("thread.ariaLabel")}>
+      <MessageScrollerContent
+        className="gap-1 py-4"                        {/* override default gap-8 for chat density */}
+        aria-busy={isLoadingOlder || undefined}       {/* suppress log announcements during older prepends — §7.1 */}
+      >
+        <MessageListInner … viewportRef={viewportRef} />   {/* useMessageScrollerScrollable / useMessageScroller live here */}
+      </MessageScrollerContent>
+    </MessageScrollerViewport>
+
+    {/* Load-older indicator is an ABSOLUTE overlay (sibling of Viewport, inside Root) — NOT a Content child */}
+    <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center pt-2"
+         aria-hidden="true">
+      {isLoadingOlder && <Spinner … /> /* or TypographyMuted t("loading.messages") */}
+    </div>
+
+    <MessageScrollerButton
+      direction="end"
+      behavior={prefersReducedMotion ? "auto" : "smooth"}   {/* JS scroll respects reduced motion — §7.2 */}
+      aria-label={t("thread.jumpToLatest")}
+    />
+  </MessageScroller>
+</MessageScrollerProvider>
+```
+
+**Why no standalone separator or sentinel children (BLOCKER fix).** The primitive's prepend-restore
+runs only when the *previous first child of Content* moves to index > 0
+(`q = w ? u.indexOf(w) : -1; if (preserveScrollOnPrependRef.current && q > 0) restore()`). A standalone
+day-separator (or a top sentinel) sitting at index 0 stays at index 0 when older **same-day** messages
+are prepended (its day is still the first day), so `q === 0`, restore is skipped, and the viewport jumps.
+Therefore:
+
+- **No standalone separator children.** `buildThreadItems` flags `isDayStart` on message items; the day
+  `Marker` renders *inside* the first `MessageScrollerItem` of the day, above the bubble (§1.2, §3).
+- **No top sentinel child.** Load-older is driven purely by the §10.2 edge trigger + §10.3 short-thread
+  fallback; the loading indicator is the absolute overlay above.
+- **Every Content child is a `MessageScrollerItem` keyed by a stable message id.** After a same-day
+  prepend the previous first item (a real message) moves to index > 0 → restore fires → no jump.
+
+`MessageListInner` maps `buildThreadItems(messages)` to items:
+
+```tsx
+{threadItems.map((item) => (
+  <MessageScrollerItem
+    key={item.message.id}
+    messageId={item.message.id}
+    className={cn(item.isGroupStart && "mt-3")}
+  >
+    {item.isDayStart && <DaySeparator timestamp={item.dayTimestamp} />}
+    {isUserChatMessage(item.message) ? (
+      <MessageBubble message={item.message} isGroupStart={item.isGroupStart} … />
+    ) : (
+      <SystemMessageBubble message={item.message} />
+    )}
+  </MessageScrollerItem>
+))}
+```
+
+The day `Marker` for the first day thus lives inside the very first item, and every subsequent day's
+Marker inside that day's first item — no index-0 non-item ever exists.
+
+### 1.2 New message row (`message-bubble.tsx`)
+
+```
+<Message align={isOwn ? "end" : "start"} id={`message-${id}`}>
+  {!isOwn && (isGroupStart
+     ? <MessageAvatar><Avatar size="sm"><AvatarFallback>{initials}</AvatarFallback></Avatar></MessageAvatar>
+     : <div className="w-8 shrink-0" aria-hidden />)}          {/* continuation spacer keeps alignment */}
+  <MessageContent>
+    {isGroupStart && (
+      <MessageHeader>
+        <span className="font-semibold text-foreground">{displayName}</span>
+        <span>{formatMessageTime(createdDate, locale, timeLabels)}</span>
+      </MessageHeader>
+    )}
+    <Bubble variant={isOwn ? "default" : "muted"} align={isOwn ? "end" : "start"}>
+      <BubbleContent>
+        {replyTo && <ReplyQuote … onClick={() => onScrollToReply(replyTo.id)} />}
+        {isDeleted ? <deleted placeholder />
+          : isEditing && isText ? <inline edit form />
+          : isText ? <text + edited indicator />
+          : <media (image | video | Attachment file chip) + optional caption />}
+      </BubbleContent>
+    </Bubble>
+    {!isGroupStart && !isDeleted && (
+      <MessageFooter className="opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 motion-safe:transition-opacity">
+        {formatMessageTime(createdDate, locale, timeLabels)}
+      </MessageFooter>
+    )}
+  </MessageContent>
+  {!isDeleted && !isEditing && <MessageActionsMenu … className="…absolute…" />}
+</Message>
+```
+
+- **Own vs. others** (must-not-regress): `Bubble variant="default"` (primary) vs. `"muted"`. Both are
+  theme-aware → light/dark legibility. `align` drives left/right + header/footer justification.
+- **Grouping:** header only on `isGroupStart`; continuation rows reveal a footer time on hover/focus
+  (`group/message` provided by `Message`).
+- **Media:** image/video bespoke inside `BubbleContent` (Attachment is a chip, not a viewer); received
+  **file** chips use `Attachment` (`AttachmentMedia` icon + `AttachmentContent` title/description +
+  `AttachmentActions` download). Caption text under the media in the same `BubbleContent`.
+- **Deleted / edited / inline-edit:** same semantics as today (italic/muted placeholder; `(edited)`;
+  in-place `Textarea` with Enter=submit, Escape=cancel).
+
+### 1.3 Reply quote (`reply-preview.tsx` + `getReplyPreviewContent`)
+
+One component, two contexts: in-bubble quote (a keyboard-reachable `<button>` firing `onScrollToReply`)
+and composer reply preview (`<div>` + ≥44px dismiss `<button>`).
+
+**Implementation requirement (review nit — current code is wrong for deleted media replies):**
+`getReplyPreviewContent` today returns `[Image]`/`[File]` for a media reply because it checks the
+resource type before deletion. The rewrite **must test deletion first**:
+
+```ts
+export function getReplyPreviewContent(
+  replyTo: ChatMessageReplyTo,
+  t: (key: string) => string,
+  deletedIds: ReadonlySet<string>,
+): string {
+  if (replyTo.deletedDate != null || deletedIds.has(replyTo.id)) return t("message.deleted"); // FIRST
+  if (replyTo.__typename === "TextChatMessage") return replyTo.content ?? t("message.deleted");
+  return replyTo.caption
+    ?? (replyTo.resource.__typename === "ImageResource"
+        ? t("message.imageAttachment")
+        : t("message.fileAttachment"));
+}
+```
+
+`deletedIds` is derived in §5.3.
+
+---
+
+## 2. Composer state machine (`message-input.tsx`)
+
+Decided coexistence model (requirements §New Capabilities 2): reply preview, attachment preview, and the
+caption/text field may all be present simultaneously.
+
+### 2.1 State
+
+```ts
+const [content, setContent] = useState("");                  // text AND caption (single field)
+const [attachedFile, setAttachedFile] = useState<File | null>(null);
+const [attachmentPreviewUrl, setAttachmentPreviewUrl] = useState<string | null>(null);
+const [attachmentError, setAttachmentError] = useState<string | null>(null); // invalid type / too large
+const [isSending, setIsSending] = useState(false);           // unifies old isSubmitting + isUploadingMedia
+// replyTo is a prop from conversation-view; onClearReply clears it there.
+```
+
+Derived (server actions still validate authoritatively; use the shared constant):
+
+```ts
+import { CHAT_MESSAGE_MAX_LENGTH } from "@/lib/constants"; // = 5000 (new shared constant, §4.4)
+const trimmed = content.trim();
+const isOverLimit = content.length > CHAT_MESSAGE_MAX_LENGTH; // gate applies to BOTH paths
+const hasFile = attachedFile !== null;
+const canSend =
+  !isSending && !disabled && !isOverLimit &&
+  (hasFile ? !attachmentError : trimmed.length > 0);
+```
+
+### 2.2 Disabled-during-send contract (review item 2 — stated explicitly)
+
+While `isSending` is true, the **entire composer input surface is disabled**: the attach menu, the
+remove-attachment control, and the textarea all receive `disabled` (this matches current behavior —
+keep it). In addition:
+
+- `handleFileSelected` and `handleRemoveAttachment` **early-return when `isSending`** (defense in depth
+  against a queued event firing mid-send).
+- On send **success**, state is cleared with **functional updaters**, and the object URL to revoke is the
+  one **captured at send start** (`urlAtSend`), so an in-flight completion can never revoke a
+  newly-staged URL nor leak the old one.
+
+### 2.3 Rendering (all sections independent)
+
+```
+{replyTo && <ReplyPreview … onDismiss={onClearReply} />}         {/* survives attaching media */}
+{attachedFile && <ChatAttachmentPreview … onRemove={handleRemoveAttachment} disabled={isSending} />}
+<div className="flex gap-2">
+  <ChatAttachmentMenu … disabled={disabled || isSending} />       {/* ≥44px */}
+  <Textarea
+    value={content}
+    onChange={…}
+    onKeyDown={handleKeyDown}
+    disabled={disabled || isSending}
+    placeholder={hasFile ? t("message.captionPlaceholder") : t("message.placeholder")}
+  />                                                               {/* ALWAYS rendered now */}
+  <Button onClick={handleSend} disabled={!canSend}>{isSending ? spinner : send}</Button>
+</div>
+{isOverLimit && (
+  <TypographyMuted className="text-destructive">
+    {hasFile ? t("message.captionTooLong", { limit: CHAT_MESSAGE_MAX_LENGTH })
+             : t("message.messageTooLong", { limit: CHAT_MESSAGE_MAX_LENGTH })}   {/* correct copy per path — review item 3 */}
+  </TypographyMuted>
+)}
+```
+
+The old `{!attachedFile && <Textarea/>}` guard is removed — the field is always visible so a caption can
+be typed alongside staged media.
+
+### 2.4 Transitions
+
+- **Attach file** (`handleFileSelected`): early-return if `isSending`; `validateFile(file, "chatMedia")`;
+  set `attachedFile`; build an image-only preview URL. **Do NOT** call `onClearReply` (removes today's
+  "attach clears reply"). **Do NOT** programmatically focus the textarea (mobile: no forced keyboard —
+  requirements §A11y). `content` retained.
+- **Remove attachment** (`handleRemoveAttachment`): early-return if `isSending`; revoke preview URL;
+  clear `attachedFile`/preview/error. **Retain `content`** (caption becomes text). Reply untouched.
+- **Dismiss reply**: `onClearReply()` only.
+- **Enter / Shift+Enter** (`handleKeyDown`): `Enter` (no shift) → `preventDefault()` + `handleSend()`;
+  `Shift+Enter` → default newline. Paste works natively.
+
+### 2.5 Send paths (`handleSend`)
+
+```ts
+async function handleSend() {
+  if (!canSend) return;
+  const urlAtSend = attachmentPreviewUrl;   // capture for safe revoke
+  setIsSending(true);
+  try {
+    if (hasFile) {
+      await onSendMedia(attachedFile!, trimmed || undefined, replyTo?.id); // media + caption + replyToId, one message
+    } else {
+      await onSendText(trimmed, replyTo?.id);
+    }
+    // success only — functional clears + revoke captured URL:
+    if (urlAtSend) URL.revokeObjectURL(urlAtSend);
+    setContent(""); setAttachedFile(null); setAttachmentPreviewUrl(null); setAttachmentError(null);
+    onClearReply();
+  } catch {
+    // Failure: KEEP content + attachment + reply for retry (toast surfaced by conversation-view).
+    // DM send-disabled: composer will be replaced by the banner; recovery text surfaced by
+    // conversation-view's error handler (§6). Nothing to clear here.
+  } finally {
+    setIsSending(false);
+  }
+}
+```
+
+Behavior change vs. today: a **generic media failure keeps** the staged attachment + caption (today's
+`catch` cleared them), mirroring the text path and preserving the user's place.
+
+### 2.6 Prop signature change
+
+```ts
+onSendMedia: (file: File, caption?: string, replyToId?: string) => Promise<void>; // CHANGED
+```
+
+---
+
+## 3. Day separators + grouping derivation (`chat-thread-utils.ts`)
+
+All placement/grouping logic is pure and clock-independent (label classification takes an explicit
+`now`), so the feature is unit-testable under a pinned timezone.
+
+### 3.1 Types
+
+```ts
+export type DayKey = string; // "YYYY-MM-DD" in the viewer's local timezone
+
+/** One render row. Day separators are NOT separate items — they render inside the first item of a day. */
+export interface MessageThreadItem {
+  message: ChatMessageNode;
+  isGroupStart: boolean; // avatar + name + time shown (forced true after a day boundary)
+  isDayStart: boolean;   // render the day Marker above this item
+  dayKey: DayKey;
+  dayTimestamp: string;  // === message.createdDate; used only to derive the day label
+}
+export type ThreadItem = MessageThreadItem;
+```
+
+### 3.2 `localDayKey`
+
+```ts
+/** Local-timezone calendar-day bucket (uses local getFullYear/getMonth/getDate → viewer tz). */
+export function localDayKey(iso: string): DayKey {
+  const d = new Date(iso);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+```
+
+Viewer-timezone bucketing satisfies "'Today' means the viewer's today"; different-timezone viewers may
+bucket the same message differently, which is correct.
+
+### 3.3 `buildThreadItems`
+
+```ts
+/**
+ * Pure. `messages` MUST be ascending by createdDate. Emits one item per message; the first message of
+ * each local day carries isDayStart=true (its item renders the day Marker). A day boundary always forces
+ * isGroupStart=true. System notices participate in grouping (they break runs via shouldShowSender) but
+ * never get their own separator.
+ */
+export function buildThreadItems(messages: ChatMessageNode[]): MessageThreadItem[] {
+  const items: MessageThreadItem[] = [];
+  let prevDayKey: DayKey | null = null;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const dayKey = localDayKey(message.createdDate);
+    const isDayStart = dayKey !== prevDayKey;
+    const isGroupStart = isDayStart || shouldShowSender(messages, i); // reuse existing rule
+    items.push({ message, isGroupStart, isDayStart, dayKey, dayTimestamp: message.createdDate });
+    prevDayKey = dayKey;
+  }
+  return items;
+}
+```
+
+The day-boundary OR guarantees the midnight-run break: same sender at 23:59 and 00:01 → the second
+message is `isDayStart` and `isGroupStart`. `buildThreadItems` is re-run on the full (prepended) array
+via `useMemo`, so newly revealed days get their Marker automatically — and because the Marker lives
+inside the day's first item, prepend-restore still works (§1.1).
+
+### 3.4 `classifyDayLabel` + `DaySeparator`
+
+```ts
+export type DayLabelKind =
+  | { kind: "today" }
+  | { kind: "yesterday" }
+  | { kind: "date"; withYear: boolean };
+
+/** Pure. Classifies `timestamp`'s local day relative to `now`'s local day. */
+export function classifyDayLabel(timestamp: string, now: Date): DayLabelKind;
+```
+
+`day-separator.tsx` (client) resolves the label via next-intl (`now` captured once via `useNow()`; the
+thread is client-rendered only, so no SSR/first-load mismatch):
+
+```tsx
+const kind = classifyDayLabel(timestamp, now);
+const label =
+  kind.kind === "today"     ? t("thread.today")
+: kind.kind === "yesterday" ? tTime("yesterday")                                  // reuse existing string
+: format.dateTime(new Date(timestamp),
+    kind.withYear ? { month: "long", day: "numeric", year: "numeric" }
+                  : { month: "long", day: "numeric" });                            // "March 3" / "March 3, 2025"
+
+return (
+  <Marker variant="separator" aria-hidden="true" className="my-2">   {/* decorative; not announced */}
+    <MarkerContent>{label}</MarkerContent>
+  </Marker>
+);
+```
+
+"Relative labels need not update live across midnight" → `useNow()` without an interval is sufficient.
+
+### 3.5 System notices vs. day separators
+
+- **Day separator** = `Marker variant="separator"` (centered label + flanking hairlines), `aria-hidden`.
+- **System notice** = `Marker` default, `className="justify-center"` (centered muted text, **no** lines,
+  **announced** as content). Deliberately different so "joined/left" is never mistaken for a date.
+
+---
+
+## 4. Data flow, queries, mutations, types
+
+### 4.1 `sendMediaMessage` — actions.ts (only contract-facing change)
+
+```ts
+const sendMediaMessageSchema = z.object({
+  chatRoomId: z.string().min(1),
+  resourceId: z.string().min(1),
+  caption: z.string().max(CHAT_MESSAGE_MAX_LENGTH).optional(), // Zod v4: use { error } not invalid_type_error
+  replyToId: z.string().min(1).optional(),
+});
+
+export async function sendMediaMessage(
+  chatRoomId: string, resourceId: string, caption?: string, replyToId?: string,
+): Promise<{ success: boolean; chatMessage?: ChatMessageNode; errorType?: string; message?: string }> {
+  const parsed = sendMediaMessageSchema.safeParse({ chatRoomId, resourceId, caption, replyToId });
+  if (!parsed.success) return { success: false, errorType: MutationErrorType.VALIDATION_ERROR, message: parsed.error.issues[0].message };
+  // authMutate({ sendChatMessage: { __args: { input: { mediaMessage: {
+  //   chatRoomId: parsed.data.chatRoomId,
+  //   resourceId: parsed.data.resourceId,
+  //   ...(parsed.data.caption ? { caption: parsed.data.caption } : {}),
+  //   ...(parsed.data.replyToId ? { replyToId: parsed.data.replyToId } : {}),
+  // } } }, … } })  — json-to-graphql-query object syntax
+}
+```
+
+`chatMessageNodeSelection` already returns `caption` + `replyTo`, so the optimistic append renders
+correctly. The composer trims the caption (`trimmed || undefined`) so all-whitespace is omitted.
+
+### 4.2 `conversation-view` handler
+
+```ts
+const handleSendMedia = async (file: File, caption?: string, replyToId?: string) => {
+  const uploadResult = await requestChatMediaUpload(file.name, file.type, file.size, roomId);
+  // …request-upload + S3 (skipped when uploadUrl null for LOCAL) …
+  const sendResult = await sendMediaMessage(roomId, uploadResult.resourceId, caption, replyToId); // CHANGED
+  // …dedup append + onLastMessageUpdate …
+};
+```
+
+### 4.3 Fragment + type change: authoritative deleted reply snippet
+
+`src/lib/graphql-fragments.ts` — add `deletedDate` to the shared `replyTo` selection (server resolves it
+live, so a reply whose original was deleted before load reports the deletion):
+
+```ts
+replyTo: {
+  __typename: true, id: true, deletedDate: true,   // ADDED
+  user: chatUserFragment,
+  __on: [
+    { __typeName: "TextChatMessage", content: true },
+    { __typeName: "MediaChatMessage", caption: true, resource: resourceFragment },
+  ],
+},
+```
+
+`src/lib/types/chat.ts` — `ChatMessageReplyToBase` gains `deletedDate: string | null` (response type:
+present, may be null). Client-only selection change; no schema change.
+
+### 4.4 Shared constant
+
+`src/lib/constants.ts` → `export const CHAT_MESSAGE_MAX_LENGTH = 5000;`. Reuse in the composer,
+`sendMessageSchema` / `updateMessageSchema` / `sendMediaMessageSchema`, and the too-long strings.
+
+### 4.5 Otherwise unchanged
+
+`loadChatRoom`, `loadMessages` (backward `last`/`before`), `loadChatRooms`, member mutations,
+subscription selection unchanged.
+
+---
+
+## 5. Real-time strengthenings (`conversation-view.tsx`)
+
+### 5.1 Reconnect: reconcile, don't remount — with honest gap reset
+
+**Problem today:** the reconnect effect sets `isLoading = true`; the `isLoading` branch returns a
+full-pane loading placeholder that **unmounts `MessageInput`** (draft lost) and resets scroll.
+
+**Design.** Reconnect must not touch `isLoading` (which gates only the initial-open placeholder). Add a
+pure reconcile plus a **gap check** (review item 5 — the earlier "filled in later" claim was wrong:
+`messagesPageInfo.startCursor` points at the *oldest* loaded message, so `before:startCursor` can only
+fetch older, never a middle gap):
+
+```ts
+/** Pure. Merge the recent window into the existing thread by id; keep older loaded history; sort asc. */
+export function reconcileMessages(
+  prev: Edge<ChatMessageNode>[], incoming: Edge<ChatMessageNode>[],
+): Edge<ChatMessageNode>[] {
+  const byId = new Map(prev.map((e) => [e.node.id, e]));
+  for (const e of incoming) byId.set(e.node.id, e);
+  return [...byId.values()].sort(
+    (a, b) => new Date(a.node.createdDate).getTime() - new Date(b.node.createdDate).getTime());
+}
+
+/** True when the newest window does NOT overlap the retained tail (>page arrived while offline). */
+export function hasReconnectGap(
+  prev: Edge<ChatMessageNode>[], incoming: Edge<ChatMessageNode>[],
+): boolean {
+  if (prev.length === 0 || incoming.length === 0) return false;
+  const retainedNewest = Math.max(...prev.map((e) => new Date(e.node.createdDate).getTime()));
+  const incomingOldest = Math.min(...incoming.map((e) => new Date(e.node.createdDate).getTime()));
+  return incomingOldest > retainedNewest; // strict: no overlap → middle gap exists
+}
+```
+
+Reconnect effect (keyed by `reconnectCounter`, `roomId`):
+
+```ts
+const [messagesData, roomData] = await Promise.all([loadMessages(roomId, 25), loadChatRoom(roomId)]);
+
+if (roomData) {
+  setRoom(roomData);
+  onRoomLoaded(roomData);                          // re-sync chat-layout activeRoom/members (review nit)
+  if (roomData.__typename === "DirectMessageChatRoom") setCanMessage(roomData.canMessage);
+}
+
+if (messagesData) {
+  const prevById = new Map(messagesRef.current.map((e) => [e.node.id, e.node])); // for editor-abandon compare
+  setMessages((prev) => {
+    if (hasReconnectGap(prev, messagesData.edges)) {
+      // Honest reset: the retained tail is disconnected from the newest window. Drop it and treat the
+      // newest 25 as a fresh load; also adopt the fresh pageInfo so load-older resumes correctly.
+      setMessagesPageInfo(messagesData.pageInfo);
+      return messagesData.edges;
+    }
+    // No gap: reconcile in place; DO NOT overwrite messagesPageInfo (preserve the older-history cursor).
+    return reconcileMessages(prev, messagesData.edges);
+  });
+  // Editor-abandon on reconcile (§5.2): compare the edited node before/after.
+  maybeAbandonEditAfterReconcile(prevById, messagesData.edges);
+}
+// DO NOT set isLoading — the pane never unmounts the composer.
+```
+
+Consequences, stated honestly:
+- **No gap (common):** older loaded history retained, cursor preserved, nodes updated in place, tail
+  appended. The composer survives (pane never renders the loading placeholder). A user reading older
+  history is not force-scrolled (`MessageScroller` follows the bottom only in `following-bottom` mode;
+  stable ids keep position). New tail messages surface the jump-to-latest button.
+- **Gap (>25 while offline, rare):** we cannot silently stitch a middle hole (it would corrupt grouping
+  and day separators across the gap). We drop the retained tail and re-render the newest 25 as a fresh
+  load — an **honest scroll reset to the bottom** via `defaultScrollPosition="end"`. Grouping/separators
+  recompute cleanly. This is the correct trade-off over showing a broken thread.
+
+Possible future API improvement to avoid the reset entirely: a forward "messages after cursor" / delta
+query (see §9).
+
+### 5.2 Editor abandon — shared helper, runs on events AND reconcile (review item 6)
+
+Factor the abandon action + change-detection into one place:
+
+```ts
+function didUserMessageChange(prev: ChatMessageNode | undefined, next: ChatMessageNode): boolean {
+  if (!prev) return true;                         // gone/replaced → treat as changed
+  if (!isUserChatMessage(prev) || !isUserChatMessage(next)) return true;
+  return prev.updatedDate !== next.updatedDate || prev.deletedDate !== next.deletedDate;
+}
+function abandonEdit() {                           // clear + non-blocking notice
+  setEditingMessageId(null);
+  toast.add({ title: t("notices.editingInterrupted"), type: "info" });
+}
+/** Reconcile path: close the editor if the edited message's node changed (or vanished). */
+function maybeAbandonEditAfterReconcile(prevById: Map<string, ChatMessageNode>, incoming: Edge<ChatMessageNode>[]) {
+  if (!editingMessageId) return;
+  const next = incoming.find((e) => e.node.id === editingMessageId)?.node;
+  if (next && didUserMessageChange(prevById.get(editingMessageId), next)) abandonEdit();
+}
+```
+
+- **`handleIncomingUpdate` / `handleIncomingDelete`:** the event node *is* the change → if
+  `message.id === editingMessageId`, call `abandonEdit()` after patching `messages`.
+- **Reconnect path:** `maybeAbandonEditAfterReconcile` compares the edited message's previous node vs.
+  the reconciled/fresh node; if changed, `abandonEdit()`. This closes the hole where a message
+  edited/deleted by others *while disconnected* would otherwise let a stale edit be saved on reconnect.
+
+The edit `Textarea` value lives in `MessageBubble` local state; forcing `isEditing=false` discards it —
+the stale edit is never silently applied. (`messagesRef` mirrors `messages` so the reconnect closure can
+read the pre-reconcile nodes without a stale-closure bug.)
+
+### 5.3 Deleted-original propagation into reply snippets
+
+`deletedMessageIds` (drives §1.3's deleted-first check for live in-session deletes of already-loaded
+originals):
+
+```ts
+const deletedMessageIds = useMemo(
+  () => new Set(messages.filter((e) => isUserChatMessage(e.node) && e.node.deletedDate).map((e) => e.node.id)),
+  [messages],
+);
+```
+
+`handleIncomingDelete` already replaces the node with `deletedDate` set → the set recomputes. Combined
+with the authoritative `replyTo.deletedDate` (§4.3) this covers both loaded-data and live cases. Also
+patch the composer's reply-in-progress: in `handleIncomingDelete`, if `replyTo?.id === message.id`,
+`setReplyTo((r) => r && { ...r, deletedDate: new Date().toISOString() })`.
+
+### 5.4 Jump-to-original "not loaded" notice
+
+```ts
+const { scrollToMessage } = useMessageScroller();
+const onScrollToReply = (id: string) => {
+  const ok = scrollToMessage(id, {
+    align: "center",
+    behavior: prefersReducedMotion ? "auto" : "smooth",   // JS scroll → pass "auto" (CSS classes don't affect scrollTo)
+  });
+  if (!ok) { toast.add({ title: t("notices.originalNotAvailable"), type: "info" }); return; }
+  flashHighlight(id); // getElementById(`message-${id}`); content-visibility:auto items stay in the DOM
+};
+```
+
+`scrollToMessage` returns `false` when the target isn't loaded → notice, never a silent no-op.
+`flashHighlight` toggles the highlight background via a `motion-safe:` transition (this is a **CSS**
+transition, so `motion-safe` is valid here); under reduced motion it shows a brief static background.
+
+### 5.5 No double-post
+
+Preserved: send handlers dedup by id before appending; the echoed `ChatMessageSentEvent` dedups on id;
+stable `MessageScrollerItem` ids mean a duplicate id never renders.
+
+---
+
+## 6. DM send-failure content recovery
+
+The send handlers know the attempted content; on `MutualFollowRequiredError` the composer unmounts (banner
+replaces it), so recovery text is surfaced by `conversation-view`'s error handler:
+
+```ts
+function handleSendError(result, attempted: { text?: string }) {
+  if (result.errorType === "MutualFollowRequiredError") {
+    setCanMessage(false);
+    toast.add({
+      title: attempted.text
+        ? t("errors.sendDisabledRecover", { content: attempted.text })  // restates attempted text/caption
+        : t("errors.sendDisabledMedia"),                                 // media with no caption
+      type: "error",
+    });
+    return;
+  }
+  toast.add({ title: result.message || t("errors.sendMessage"), type: "error" });
+}
+```
+
+`handleSendText` passes `{ text: content }`; `handleSendMedia` passes `{ text: caption }` (may be
+undefined → `sendDisabledMedia`). Satisfies "at minimum the attempted text is restated in the visible
+error."
+
+---
+
+## 7. Accessibility & interaction
+
+### 7.1 Free from the primitives (verified in `@shadcn/react` compiled source)
+
+- `MessageScrollerViewport` → `role="region"`, `aria-label` (default "Messages" → override with
+  `t("thread.ariaLabel")`), `tabIndex=0` (keyboard scroll region with arrow/Home/End/PageUp-Down).
+- `MessageScrollerContent` → `role="log"` + `aria-relevant="additions"` → incoming messages announced
+  **politely** (implicit `aria-live=polite`) without stealing focus — the requirement, for free.
+- `MessageScrollerButton` → `inert`/`tabIndex=-1` when inactive, focusable when `data-active=true`.
+
+**Suppress announcements during older prepends (review item 8).** `role=log` + `aria-relevant="additions"`
+would otherwise announce prepended history as "new". Set `aria-busy` on the Content log while older
+history loads: `<MessageScrollerContent aria-busy={isLoadingOlder || undefined}>`. Assistive tech pauses
+live output while `aria-busy=true`; because the prepend completes within the busy window and no *new*
+additions occur when it flips back to false, older history is not announced. Incoming **tail** messages
+(never during `isLoadingOlder`) still announce normally.
+
+### 7.2 What we add
+
+- **Day separators** `aria-hidden="true"` (decorative, not announced as content).
+- **All actions keyboard-reachable** (not hover-only): reply/edit/delete via `MessageActionsMenu`
+  (focusable trigger + arrow-navigable menu); reply-quote jump is a `<button>`; back/members/attach are
+  buttons; jump-to-latest is the primitive button; inline-edit Save/Cancel are buttons. Hover-reveal uses
+  `group-focus-within`/`focus:` so keyboard focus reveals them.
+- **Reduced motion** (reduced, not removed). Critical correction: **CSS `motion-safe` classes do NOT
+  affect JS `scrollTo`.** For every JS-driven scroll, pass `behavior: "auto"` when reduced:
+  - jump-to-latest → `<MessageScrollerButton behavior={prefersReducedMotion ? "auto" : "smooth"}>`;
+  - `scrollToMessage(...)` → `behavior: prefersReducedMotion ? "auto" : "smooth"` (§5.4);
+  - auto-follow on new messages already uses instant scroll.
+  Purely-CSS motions (reply-highlight flash, hover/focus opacity) stay gated with `motion-safe:`.
+  `prefersReducedMotion` comes from a `matchMedia("(prefers-reduced-motion: reduce)")` hook.
+- **44×44 touch targets** (current gaps: Button `icon`=36px, `icon-lg`=40px):
+  - **Attach button** (`chat-attachment-menu.tsx`, currently 40px wide) → ≥44px (`size-11`/`min-w-11`).
+  - **Per-message action trigger** (`message-actions-menu.tsx`, currently 24px) → ≥44px touch target on
+    mobile (expand tap area; keep the visual icon subtle).
+  - **Back / members** (`conversation-header.tsx`, 36px) → ≥44px on mobile. Send (60px) OK.
+- **Mobile keyboard**: staging an attachment does not auto-focus the caption field (§2.4).
+- **Locale-aware, hydration-stable dates**: bubble/room-list via existing `Intl.DateTimeFormat` helpers;
+  day-separator labels + member joined date via `useFormatter`.
+
+---
+
+## 8. i18n — new/changed strings (`messages/en.json`, under `chat`)
+
+Loading strings end with "…" (never "..."); Title Case for buttons/headings; numerals for counts.
+
+| Key | Value | Purpose |
+| --- | --- | --- |
+| `thread.today` | `Today` | Day separator (Yesterday reuses `time.yesterday`). |
+| `thread.ariaLabel` | `Messages` | Localizes the scroller viewport `aria-label`. |
+| `thread.jumpToLatest` | `Jump to Latest` | Jump-to-latest button label (replaces `newMessages`). |
+| `loading.conversation` | `Loading conversation…` | Conversation pane (replaces hardcoded `Loading...`). |
+| `loading.messages` | `Loading messages…` | Thread load-older overlay (replaces hardcoded). |
+| `loading.rooms` | `Loading conversations…` | Room list (replaces hardcoded). |
+| `message.captionPlaceholder` | `Add a caption…` | Textarea placeholder when media is staged. |
+| `message.captionTooLong` | `Caption is too long. Keep it under {limit} characters.` | Over-limit, media staged. |
+| `message.messageTooLong` | `Message is too long. Keep it under {limit} characters.` | Over-limit, no media. |
+| `errors.loadOlder` | `Couldn't load older messages. Scroll up to try again.` | Failed load-older toast (§10.2). |
+| `notices.originalNotAvailable` | `That message isn't loaded yet. Scroll up to find it.` | Jump-to-original miss. |
+| `notices.editingInterrupted` | `This message changed, so your edit wasn't saved.` | Editor abandon (§5.2). |
+| `errors.sendDisabledRecover` | `You can no longer message this person. Your unsent message: "{content}"` | DM send-disabled text/caption recovery. |
+| `errors.sendDisabledMedia` | `You can no longer message this person, so your photo or video wasn't sent.` | DM send-disabled, media without caption. |
+
+Reused unchanged: `time.yesterday`, `message.deleted`/`edited`/`imageAttachment`/`fileAttachment`,
+`members.joined`, dialog strings. Orphaned: `chat.newMessages` (removed in the same PR).
+
+---
+
+## 9. Alternatives, trade-offs, API feedback
+
+- **`MessageScroller` vs. bespoke scroll code.** Adopting the primitive is the point of the revamp,
+  removes ~120 lines of fragile scroll/observer/preserve code, and yields `role=log`/`region` + the
+  jump-to-latest button. Trade-off: we honor its prepend-restore contract (separators inside items,
+  no index-0 non-item — §1.1) and its scrollable-store timing (§10).
+- **`Attachment` for media vs. bespoke image/video.** `Attachment` is a chip; images/videos need a real
+  viewer → bespoke in `BubbleContent`. Intentional.
+- **Deleted-reply propagation** via `replyTo.deletedDate` (authoritative on load) + an in-session set
+  (live deletes of loaded originals). Client-only selection change, no schema change.
+- **Reconnect >25-message gap** is reset honestly (§5.1) rather than stitched. **API suggestion
+  (non-blocking):** a forward "messages after cursor"/delta query would let reconnect fetch exactly the
+  missed messages and avoid the reset.
+- **CSS utility prerequisite (verify before implementation):** the primitives reference `scroll-fade-b`,
+  `scroll-fade-x`, `scrollbar-thin`, `scrollbar-gutter-stable` (message-scroller.tsx, attachment.tsx),
+  which are **not** defined in `src/app/globals.css` (`shimmer` and `contain-content` are fine). Either
+  add the `@utility` definitions the shadcn registry expects, or accept cosmetic degradation (native
+  scrollbars, no fade masks). Non-blocking; recommend adding them.
+
+---
+
+## 10. Hard-won `MessageScroller` notes (bake in)
+
+1. **Provider config:** `autoScroll` + `defaultScrollPosition="end"` + `scrollEdgeThreshold={100}`
+   (primitive default is 8px; 100px restores the old near-bottom follow window).
+2. **Load-older is edge-triggered (no sentinel child).** `useMessageScrollerScrollable()` starts as a
+   placeholder `{ start:false, end:false }` **before** measurement and updates on a deferred rAF (a stale
+   window exists right after a prepend). A level-triggered `if (!start) load()` eagerly fetches every
+   mount and double-fires in the stale window. Fire only on the true→false transition, via a prev-ref:
+
+   ```ts
+   const { start } = useMessageScrollerScrollable();
+   const prevStart = useRef(start);
+   useEffect(() => {
+     const was = prevStart.current;
+     prevStart.current = start;
+     if (was && !start && hasOlderMessages && !isLoadingOlder) onLoadOlder();
+   }, [start, hasOlderMessages, isLoadingOlder, onLoadOlder]);
+   ```
+
+   **On failure** (`handleLoadOlder` catch): toast `t("errors.loadOlder")` **and re-arm** the trigger by
+   setting `prevStart.current = true`, so scrolling to the top again re-fires (a scroll-away/scroll-back
+   otherwise wouldn't re-fire because the consumed transition left `prevStart=false`). Success path leaves
+   `prevStart` as-is.
+
+3. **Short-thread fallback (top edge unreachable → `start` never transitions).** Measure via a ref to the
+   **viewport** (not a Content sentinel), in rAF, guarded, and **guarded against a failure busy-loop** by
+   only firing when the item count changed:
+
+   ```ts
+   const lastFallbackCount = useRef(-1);
+   useEffect(() => {
+     if (!hasOlderMessages || isLoadingOlder) return;
+     if (lastFallbackCount.current === threadItems.length) return; // don't re-fire on a failed attempt
+     const raf = requestAnimationFrame(() => {
+       const vp = viewportRef.current;
+       if (vp && vp.scrollHeight <= vp.clientHeight) {
+         lastFallbackCount.current = threadItems.length;
+         onLoadOlder();
+       }
+     });
+     return () => cancelAnimationFrame(raf);
+   }, [hasOlderMessages, isLoadingOlder, onLoadOlder, threadItems.length, viewportRef]);
+   ```
+
+   (`viewportRef` is set via `<MessageScrollerViewport ref={viewportRef}>` — the primitive Viewport merges
+   a passed ref; do **not** pass a ref to Root, which overwrites its own internal ref.)
+
+4. **`preserveScrollOnPrepend` (default true) requires the previous first child to move to index > 0.**
+   Standalone separators/sentinels at index 0 defeat it (BLOCKER). Every Content child is a
+   `MessageScrollerItem` keyed by a stable server message id; separators render inside the day's first
+   item (§1.1, §3.3). No optimistic temp ids in conversation-view.
+
+5. **`scrollToMessage(messageId)`** targets `Item` `messageId` values and returns `false` when not loaded
+   (drives §5.4). The highlight flash keeps using `getElementById(`message-\${id}`)` — `content-visibility:auto`
+   items stay in the DOM.
+
+6. **Root layout:** root is `relative size-full min-h-0`; `className="flex-1"` inside conversation-view's
+   flex column is correct. The load-older overlay is an absolute sibling of Viewport inside Root.
+
+7. **Hooks inside the provider only:** `Provider > Root > MessageListInner`.
+
+---
+
+## 11. Test plan
+
+### 11.1 Unit tests (Vitest) — required for pure derivation, timezone pinned
+
+**Pin the timezone** so `localDayKey`/`classifyDayLabel` are deterministic (they use local `Date`
+methods). Set `TZ` for the vitest run — add `env: { TZ: "America/New_York" }` under `test` in the vitest
+config (or `process.env.TZ = "America/New_York"` in a test-setup file) and document the pinned zone at the
+top of the spec. Author fixtures in that zone, including at least one case where the **UTC day and the
+local day differ** (e.g. `2025-03-03T04:30:00Z` = `2025-03-02 23:30` local) to prove local-tz bucketing;
+avoid DST-transition dates.
+
+New file `__tests__/components/chat/chat-thread-utils.test.ts` (mirrors the src path; follows
+`participant-utils.test.ts`). `classifyDayLabel` receives an explicit `now`, never the wall clock.
+
+`buildThreadItems` (returns message items with `isDayStart`/`isGroupStart`):
+- Single day: exactly the first item has `isDayStart=true`; grouping matches `shouldShowSender`.
+- Two days: the first item of day 2 has `isDayStart=true` and `isGroupStart=true`.
+- **Midnight-spanning sender run:** same sender at 23:59 and 00:01 (local), <5 min apart → the second item
+  is `isDayStart` and `isGroupStart` (day boundary overrides the 5-min rule).
+- Cross-tz case: a message whose UTC and local days differ buckets by local day.
+- System notice: breaks the run, sits inside its day, has `isDayStart` only if it is the day's first item;
+  never produces a standalone separator.
+- Prepend simulation: calling with an older-extended array yields correct `isDayStart` flags for revealed
+  days.
+
+`localDayKey`: same local day → equal keys; across local midnight → different keys; cross-tz difference.
+
+`classifyDayLabel(now)`: today / yesterday / older-same-year (`withYear:false`) / previous-year
+(`withYear:true`) / local-midnight boundary.
+
+`reconcileMessages` / `hasReconnectGap`:
+- reconcile upserts a changed node in place (edit/delete), inserts a new tail in sorted position, retains
+  older history, dedups by id.
+- `hasReconnectGap` false when the newest window overlaps the retained tail (≤page arrived); true when the
+  newest window's oldest is strictly newer than the retained tail's newest (>page arrived).
+
+### 11.2 Playwright — assume a full selector rewrite
+
+- Prefer role/label/text selectors tied to i18n strings and the primitives' `data-slot` attributes
+  (`[data-slot="bubble-content"]`, `[data-slot="message"]`, `[data-slot="attachment"]`,
+  `[data-slot="marker"]`). Add a few `data-testid`s where ambiguous (`data-testid="day-separator"`;
+  message rows keyed by `id="message-<id>"`).
+- Keep the four existing specs in `tests/pages/chat.spec.ts` (unauth redirect, layout renders, rooms error,
+  empty state), updating selectors.
+- MSW factories in `tests/fixtures/mock-data/chat.ts`: (a) a room with messages spanning two calendar days;
+  (b) a request-upload response with `uploadUrl: null` (LOCAL skips S3). **The `sendChatMessage` handler
+  must branch on `input.mediaMessage` vs. `input.textMessage`** and, for the media branch, **echo back the
+  provided `caption`** in the returned `MediaChatMessage` (otherwise the caption spec can't assert render).
+
+Two new specs:
+- `tests/pages/chat-day-separator.spec.ts`: open a room via `?room=…` whose messages straddle a day
+  boundary; assert `[data-testid="day-separator"]` (and/or the localized "Today"/date text) is visible and
+  the first message after the boundary shows its sender header.
+- `tests/pages/chat-caption.spec.ts`: open a room; set the hidden file input's files; type a caption; click
+  Send; assert the echoed caption renders with the media (LOCAL path).
+
+### 11.3 Manual WebSocket checklist (harness can't cover fetch-intercepted WS)
+
+Receive / edit / delete from a second participant; **editor abandon on remote change**; **reconnect with an
+in-progress draft** (text + staged attachment + caption + reply-in-progress all survive; a user reading
+older history is not force-scrolled; new messages reconcile — and, separately, verify the honest reset when
+>25 messages arrived while offline); unread + reorder; member add/remove while open; no double-post;
+deleted-original propagates into a visible reply snippet; jump-to-original not-loaded notice; DM
+send-disabled recovery restates the attempted text/caption.
+
+### 11.4 Manual functional pass + scroll-jump assertion
+
+Text + each media type; captions on send (with and without a reply); replies + jump (incl. not-loaded
+original); inline edit; delete + confirmation; grouping + day separators (incl. a midnight-spanning run);
+full members panel; DM vs. group; create-DM / create-group; light + dark; desktop two-pane + mobile
+single-pane.
+
+**Explicit no-jump check (validates the BLOCKER fix):** with the thread scrolled up mid-history, trigger a
+**same-day** older-history load and assert **zero `viewport.scrollTop` delta** across the prepend (capture
+`scrollTop` before the fetch resolves and after the prepend paints; they must be equal). Repeat for a
+cross-day prepend.
+
+---
+
+## 12. Implementation order (suggested)
+
+1. `chat-thread-utils.ts` (+ `reconcileMessages`/`hasReconnectGap`) + unit tests with pinned `TZ`.
+2. `src/lib/constants.ts` `CHAT_MESSAGE_MAX_LENGTH`; fragment/type change (§4.3–4.4);
+   `actions.ts` `sendMediaMessage` caption/replyToId.
+3. `message-list.tsx` on `MessageScroller` (§1.1, §10) with `MessageBubble`, `SystemMessageBubble`,
+   `day-separator.tsx`; `getReplyPreviewContent` deleted-first.
+4. `message-input.tsx` composer state machine + `chat-attachment-preview.tsx` + `chat-attachment-menu.tsx`.
+5. `conversation-view.tsx` reconnect reconcile + gap reset, editor-abandon helper, deleted-reply
+   propagation, jump notice, DM recovery, `onSendMedia` signature, `onRoomLoaded` on reconnect.
+6. Restyle room list / row / header / members panel; localize the three loading strings.
+7. i18n strings; a11y/touch/reduced-motion passes; verify CSS utilities (§9).
+8. Playwright selector rewrite + two new specs + mock data (media/text branch); run unit + Playwright
+   (chromium), incl. the same-day no-jump assertion.

--- a/.claudedoc/chat-shadcn-revamp/manual-checklist.md
+++ b/.claudedoc/chat-shadcn-revamp/manual-checklist.md
@@ -1,0 +1,89 @@
+# Chat Revamp — Manual Verification Checklist
+
+Covers behaviors the Playwright/MSW harness cannot automate (WebSocket-driven
+real-time, multi-participant, reconnect) plus the visual/feel checks a single-PR
+full-surface rewrite requires. Run with two browsers signed in as two mutual-follow
+users (A and B) sharing a DM and a group room. Check each item in both light and
+dark themes; run the mobile section in a phone-width viewport.
+
+## Real-time (two participants)
+
+- [ ] B sends a text message → appears live for A without refresh; A pinned at the
+      bottom auto-scrolls; A scrolled up does NOT get yanked and the jump-to-latest
+      arrow is available.
+- [ ] B edits a message → A sees the new content and the "edited" indicator live.
+- [ ] B deletes a message → A sees the deleted placeholder live.
+- [ ] B deletes/edits the exact message A is inline-editing → A's editor closes with
+      the "editing interrupted" notice; A's stale draft is NOT applied.
+- [ ] B deletes a message that A's later message replies to → A's reply quote flips
+      to the deleted placeholder.
+- [ ] A sends a message → it appears exactly once (no double-post from the echo).
+- [ ] Room list: a message arriving in a room A doesn't have open shows the unread
+      dot and reorders that room to the top; opening the room clears the dot.
+- [ ] Group: B (owner) adds/removes a member while A has the members panel open →
+      roster updates live; removing A kicks A out immediately.
+
+## Reconnect
+
+- [ ] With a reply staged, a file attached, and a caption typed: kill the network
+      (devtools offline) until the socket drops, then restore. On reconnect the
+      composer keeps the reply + attachment + caption; the thread does not remount
+      or flash a full-pane loading state.
+- [ ] While offline, B sends 2–3 messages → on reconnect they appear merged into
+      the thread in order; A's scroll position is preserved if A was reading history.
+- [ ] While offline, B sends >25 messages → on reconnect the thread performs the
+      honest reset (fresh newest page, scrolled to bottom) rather than showing a
+      silent gap.
+
+## Composer state machine
+
+- [ ] Reply + attachment + caption all visible at once; dismissing the reply keeps
+      the attachment/caption; removing the attachment keeps the typed text as a
+      normal message draft and keeps the reply.
+- [ ] Enter with attachment staged sends media + caption (+ reply target if set);
+      Shift+Enter inserts a newline.
+- [ ] Send in flight: attach menu, remove-attachment, and textarea are disabled;
+      nothing can be re-staged or cleared mid-send.
+- [ ] Upload failure: attachment is retained for retry; error toast shown.
+- [ ] Caption > 5000 chars with media staged: Send disabled + caption-specific
+      inline error. Text > 5000 without media: Send disabled + message-specific
+      error.
+- [ ] DM where mutual follow was just lost: send fails, composer flips to the
+      banner, and the error restates the attempted text so nothing is silently lost.
+
+## Thread rendering & scrolling
+
+- [ ] Open a long room: lands at the newest message; scrolling to the top loads
+      older history with ZERO visual jump — including when the loaded page is the
+      same calendar day as the current top (the prepend-restore case).
+- [ ] Load-older failure (kill network, scroll to top): error toast; restoring the
+      network and scrolling again retries (no dead-end).
+- [ ] Day separators: correct Today/Yesterday/absolute labels in the viewer's local
+      timezone; a sender run spanning midnight regroups after the separator (avatar
+      + name shown again).
+- [ ] Reply quote tap: jumps + highlights when loaded; shows the "original not
+      available" notice when the original isn't loaded (deep history).
+- [ ] Received file message renders as a file chip with name/size/download; images
+      open full-size; videos play inline; captions render with media.
+
+## Accessibility & mobile
+
+- [ ] Keyboard-only pass: reply/edit/delete via the actions menu, jump-to-latest,
+      members, back — all reachable and operable without a mouse.
+- [ ] Screen reader (VoiceOver/NVDA spot-check): incoming messages announced
+      politely; loading older history does NOT announce 25 old messages; day
+      separators are not read as content.
+- [ ] OS reduced-motion enabled: jump-to-latest and reply-jump scroll instantly
+      (no smooth animation); highlight flash is subdued/absent.
+- [ ] Mobile viewport: single-pane nav with back; composer + send visible above the
+      on-screen keyboard; staging an attachment does not force the keyboard open;
+      all touch targets (send, attach, actions, members, back) comfortably tappable
+      (≥44px); tab bar does not overlap the conversation.
+
+## Cross-cutting
+
+- [ ] Both themes: own-vs-others bubbles clearly distinguished; contrast holds.
+- [ ] Members panel: add/remove/promote/demote/transfer/leave flows intact; joined
+      dates render in the app locale; names use display names.
+- [ ] Create DM (idempotent — reopens existing) and create group (2+ members,
+      name required) flows intact.

--- a/.claudedoc/chat-shadcn-revamp/manual-checklist.md
+++ b/.claudedoc/chat-shadcn-revamp/manual-checklist.md
@@ -51,6 +51,20 @@ dark themes; run the mobile section in a phone-width viewport.
 - [ ] DM where mutual follow was just lost: send fails, composer flips to the
       banner, and the error restates the attempted text so nothing is silently lost.
 
+## Message actions (baseline, self-triggered)
+
+- [ ] Inline edit an own text message: enter edit from the actions menu, change
+      the text, Enter saves (updated content + "edited" indicator), Escape
+      cancels leaving the message unchanged; the Save/Cancel buttons do the same.
+- [ ] Delete an own message: confirmation dialog appears; confirming replaces the
+      message with the deleted placeholder; cancelling leaves it intact.
+- [ ] As Owner/Admin in a group, delete another member's message (same
+      confirmation flow); as a plain Member, verify no delete on others' messages.
+- [ ] Paste text into the composer, and into the caption field with media staged —
+      both always work.
+- [ ] Send a video specifically: stage, caption, send; it renders as an inline
+      player with controls and its caption.
+
 ## Thread rendering & scrolling
 
 - [ ] Open a long room: lands at the newest message; scrolling to the top loads
@@ -85,5 +99,7 @@ dark themes; run the mobile section in a phone-width viewport.
 - [ ] Both themes: own-vs-others bubbles clearly distinguished; contrast holds.
 - [ ] Members panel: add/remove/promote/demote/transfer/leave flows intact; joined
       dates render in the app locale; names use display names.
+- [ ] DM members panel: roster renders WITHOUT the group-management controls
+      (no add member, no promote/demote/remove).
 - [ ] Create DM (idempotent — reopens existing) and create group (2+ members,
       name required) flows intact.

--- a/.claudedoc/chat-shadcn-revamp/qa-report.md
+++ b/.claudedoc/chat-shadcn-revamp/qa-report.md
@@ -1,0 +1,303 @@
+# QA Verification: Chat Revamp (shadcn chat primitives)
+
+Branch: `0102-chat-shadcn-revamp`. Contract: `.claudedoc/chat-shadcn-revamp/requirements.md` (final).
+Design: `.claudedoc/chat-shadcn-revamp/design.md`. Full diff: `git diff ce6443c...HEAD` (39 files,
++3950/-531), commits `0ea32cb`, `52add80`, `ea39cca`, `e33b7c4`, `b82784c`.
+
+Method: every item below was checked against the actual implementation (not the design doc's word),
+file:line cited. Status legend: **VERIFIED** (code demonstrably implements it), **PARTIAL**
+(implemented with a caveat, noted), **NOT-IMPLEMENTED**, **MANUAL** (requires a human/second browser,
+confirmed the manual checklist covers it).
+
+---
+
+## 1. Feature-Parity Inventory
+
+### 1.1 Layout and navigation
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Two-pane desktop / single-pane mobile | VERIFIED | `chat-layout.tsx:254-304` (unchanged, no diff vs. pre-revamp) |
+| Empty right pane prompt | VERIFIED | `chat-layout.tsx:294-303`, `chat.noConversation` string |
+| Open room reflected in URL | VERIFIED | `chat-layout.tsx:93-100` (`router.replace(...?room=...)`) |
+
+### 1.2 Room list
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| "New Chat" entry point | VERIFIED | `chat-room-list.tsx:180-183,209-212` |
+| Row: avatar/name/preview/relative time | VERIFIED | `chat-room-list-item.tsx:86-131` |
+| Last-message preview for every kind (text/image/file/deleted/system) | VERIFIED | `chat-room-list-item.tsx:52-84` |
+| Session-local unread dot, clears on open | VERIFIED (unchanged) | `chat-layout.tsx:79,128,149,212-217`; no diff to this logic |
+| Reorder to top on activity | VERIFIED (unchanged) | `chat-room-list.tsx:99-121` (`roomListEvent` upsert prepends) |
+| Infinite scroll (older rooms) | VERIFIED (unchanged) | `chat-room-list.tsx:136-173` |
+| Empty state + path to find people | VERIFIED | `chat-room-list.tsx:176-204`, links to `/search` |
+
+### 1.3 Conversation header
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Room/person display name | VERIFIED | `conversation-header.tsx:40-45` |
+| Members button opens panel | VERIFIED | `conversation-header.tsx:48-56` |
+| Back affordance (mobile) | VERIFIED | `conversation-header.tsx:29-38` (`md:hidden`) |
+
+### 1.4 Message thread
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Chronological, paginated backward, auto-scroll on open/new-at-bottom | VERIFIED | `message-list.tsx:81-85` (`MessageScrollerProvider autoScroll defaultScrollPosition="end"`); primitive's "following-bottom" mode confirmed in `node_modules/@shadcn/react/dist/message-scroller/index.js` |
+| Jump-to-latest when scrolled up; no force-scroll | VERIFIED | `message-list.tsx:123-127` (`MessageScrollerButton`); primitive tracks scroll intent (`userScrollIntent`) |
+| Load older on scroll-to-top, no visual jump | VERIFIED | `message-list.tsx:169-210` (edge-triggered + short-thread fallback); Playwright: `tests/pages/chat.spec.ts:197-314` asserts `Math.abs(after-before) <= 100` across a same-day prepend |
+| Sender grouping (avatar/name/time once per run, hover time on continuation) | VERIFIED | `chat-thread-utils.ts:46-66` (`buildThreadItems`/`shouldShowSender`); `message-bubble.tsx:106-125,261-265` |
+| Own vs. others visually distinguished | VERIFIED | `message-bubble.tsx:127-130` (`Bubble variant="default"|"muted"`, `align`) |
+| Text w/ line breaks | VERIFIED | `message-bubble.tsx:168-170` (`whitespace-pre-wrap`) |
+| Image thumbnail → opens full image | VERIFIED | `message-bubble.tsx:179-195` (`<a target=_blank>` + `<img>`) |
+| Video inline player w/ controls | VERIFIED | `message-bubble.tsx:196-204` (`<video controls>`) |
+| File chip (name/size/download), receive-only | VERIFIED | `message-bubble.tsx:205-234` (`Attachment`/`AttachmentTrigger`/`AttachmentActions`); composer still can't send generic files (`chat-attachment-menu.tsx` accepts only `chatMedia`) |
+| Media caption displays with media | VERIFIED | `message-bubble.tsx:236-240` |
+| Reply quote: shows author+snippet, tap jumps+highlights | VERIFIED | `message-bubble.tsx:132-144`, `message-list.tsx:212-226` (`scrollToMessage` + `flashHighlight`) |
+| Quoted snippet flips to deleted placeholder (loaded/live) | VERIFIED | `message-preview-utils.ts:32-49` (deleted-first check using `replyTo.deletedDate` + live `deletedMessageIds`); fragment change `graphql-fragments.ts` (+`deletedDate` on `replyTo`) |
+| Jump-to-original "not loaded" notice, never silent no-op | VERIFIED | `message-list.tsx:212-226` (`toast.add(t("notices.originalNotAvailable"))` when `scrollToMessage` returns `false`) |
+| Edited indicator | VERIFIED | `message-bubble.tsx:171-175` (`(edited)` on `updatedDate`) |
+| Deleted placeholder, muted/italic | VERIFIED | `message-bubble.tsx:131,146-147` |
+| System notices centered, non-bubble | VERIFIED | `system-message-bubble.tsx` (`Marker`, `justify-center`, no `Bubble`) |
+
+### 1.5 Message actions
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Reply (any message), Edit (own text only), Delete (own, or Owner/Admin any) | VERIFIED | `message-actions-menu.tsx:57-68`, `message-bubble.tsx:76,250` |
+| Delete confirmation | VERIFIED (unchanged) | `delete-message-dialog.tsx` (no diff — pre-existing `AlertDialog`), wired via `conversation-view.tsx:503-506,450-481` |
+| Inline edit, Enter=submit / Escape=cancel | VERIFIED | `message-bubble.tsx:95-102,148-165` |
+| **Baseline (self-triggered) inline-edit / delete flows have no automated test and no dedicated manual-checklist line** | **GAP (see §6, medium)** | see Gaps |
+
+### 1.6 Message input (composer)
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Placeholder, Enter sends / Shift+Enter newline | VERIFIED | `message-input.tsx:108-114,196` |
+| Attachment entry (photo/video, existing limits) | VERIFIED (unchanged) | `chat-attachment-menu.tsx` (`getAcceptAttribute("chatMedia")`, `validateFile`) |
+| Busy/loading state while sending | VERIFIED | `message-input.tsx:52,75-105,208-212` (`isSending`, `Loader2`) |
+| Coexistence: reply + attachment + caption all visible at once; attach no longer clears reply | VERIFIED | `message-input.tsx:116-149,162-184` (field always rendered; `handleFileSelected` never calls `onClearReply`) |
+| Dismissible reply preview above composer | VERIFIED | `message-input.tsx:163-172`, `reply-preview.tsx:60-77` |
+| Attachment staging preview (thumbnail/video icon, name/size, remove) | VERIFIED | `chat-attachment-preview.tsx` |
+| File validation before send, clear inline error | VERIFIED | `message-input.tsx:120-133`, `chat-attachment-preview.tsx:55-59` |
+| DM send-disabled → banner replaces composer | VERIFIED | `conversation-view.tsx:556-565` |
+
+### 1.7 Members panel
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Roster: name, role badge (group), joined date, "(You)" | VERIFIED | `member-list-panel.tsx:268-301` — `t("you")` now localized (was hardcoded `" (You)"`) |
+| Name uses `displayName`; joined date app-locale via `useFormatter` | VERIFIED (this was the pre-existing gap the requirements called out — now fixed) | `member-list-panel.tsx:268(diff),296-300` (was `getFullName` + `toLocaleDateString()`; now `member.user.displayName` + `format.dateTime(..., {dateStyle:"medium"})`) |
+| Add via mutual-follow picker (group only) | VERIFIED (unchanged) | `member-list-panel.tsx:252-261,358-390` |
+| Remove, role rules | VERIFIED (unchanged) | `member-list-panel.tsx:48-52,304-346` |
+| Promote/demote (Owner only) | VERIFIED (unchanged) | `member-list-panel.tsx:306-325` |
+| Transfer ownership + confirmation | VERIFIED (unchanged) | `member-list-panel.tsx:189-212,403-419` |
+| Leave chat (non-owner) + confirmation; owner told to transfer first | VERIFIED (unchanged) | `member-list-panel.tsx:214-230,238-248,421-437` |
+| DM panel hides group-management controls | VERIFIED (unchanged) | `member-list-panel.tsx:238,252,281,304` (`!isDirectMessage` guards) |
+
+### 1.8 Create / DM flow
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| New-chat picker over mutual follows | VERIFIED (unchanged, no diff) | `create-chat-room-dialog.tsx`, `mutual-follow-selector.tsx` |
+| 1 person → idempotent DM; 2+ → group, name required | VERIFIED (unchanged) | `actions.ts` `createDirectMessage`/`createGroupChat`, unit-tested in `__tests__/[locale]/chat/actions.test.ts:379-540` |
+| Mutual-follow requirement enforced w/ clear message | VERIFIED (unchanged) | `mutualFollowRequired` string, error surfacing in dialog |
+
+### 1.9 Real-time behavior
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Live message/edit/delete, membership updates | MANUAL (WebSocket, not harness-coverable) | checklist "Real-time (two participants)" §1-3,8 |
+| Unread + reorder live | MANUAL | checklist item 7 |
+| Reconnect reconciles, doesn't unmount composer/force-scroll | VERIFIED (code) + MANUAL (behavioral) | `conversation-view.tsx:268-321` (`reconcileMessages`/`hasReconnectGap`, no `isLoading` touch); unit-tested pure logic in `chat-thread-utils.test.ts:224-298`; live behavior in checklist "Reconnect" §1-3 |
+| Editor closes + notice on remote edit/delete of the message being edited | VERIFIED (code) + MANUAL | `conversation-view.tsx:46-57,111-115,148-182,304-314` (`didUserMessageChange`/`abandonEdit`/`maybeAbandonEditAfterReconcile`); checklist item 4 |
+| No double-post of own message | VERIFIED (code) + MANUAL | dedup-by-id in `handleSendText`/`handleSendMedia`/`handleIncomingMessage` (`conversation-view.tsx:117-146,340-417`); checklist item 6 |
+| Removal from room reflected immediately | VERIFIED (unchanged code) + MANUAL | `chat-layout.tsx:162-179` |
+
+### 1.10 Error handling
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Clear, non-blocking failure notices; app doesn't crash | VERIFIED | `conversation-view.tsx` toasts throughout; `handleLoadOlder`/`triggerLoadOlder` toast + re-arm (`message-list.tsx:176-192`) |
+| Failed send never appears as sent | VERIFIED | `message-input.tsx:89-95` (state kept on `catch`, nothing appended) |
+| Mutual-follow lost at send time → banner, attempted content restated | VERIFIED | `conversation-view.tsx:323-338` (`handleSendError` → `sendDisabledRecover`/`sendDisabledMedia`), strings in `en.json` |
+
+---
+
+## 2. New Capabilities
+
+### 2.1 Day separators
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Grouped by calendar day, slim centered separator | VERIFIED | `day-separator.tsx`, `Marker variant="separator"` |
+| Label: Today / Yesterday / locale-aware absolute date (+year if different) | VERIFIED | `chat-thread-utils.ts:78-89` (`classifyDayLabel`), `day-separator.tsx:26-37`; unit-tested `chat-thread-utils.test.ts:85-129` |
+| Separator above first message of each new day, incl. top of loaded history; correct after prepend | VERIFIED | `chat-thread-utils.ts:46-66` (`buildThreadItems`, re-run via `useMemo` on full array); unit-tested `chat-thread-utils.test.ts:202-221`; Playwright same-day-prepend spec `chat.spec.ts:197-314` |
+| Day boundary always breaks sender-grouping run (even <5min, same sender) | VERIFIED | `chat-thread-utils.ts:54-55` (`isGroupStart = isDayStart \|\| shouldShowSender`); unit-tested `chat-thread-utils.test.ts:160-173` (midnight-spanning run) |
+| System notices sit within their day, no own separator | VERIFIED | `chat-thread-utils.test.ts:188-200` |
+| Purely presentational, not selectable/actionable | VERIFIED | `day-separator.tsx:41` (`aria-hidden="true"`, no click handler) |
+| Computed in viewer's local timezone | VERIFIED | `chat-thread-utils.ts:26-37` (`localDayKey` uses local `Date` getters); cross-tz fixture in `chat-thread-utils.test.ts:78-82,175-186` |
+| Relative labels need not update live across midnight | VERIFIED (by design) | `day-separator.tsx:24` (`useNow()`, no interval) |
+| Playwright coverage | VERIFIED | `chat.spec.ts:64-157` (day-boundary render + label assertions + send-still-works) |
+
+### 2.2 Caption on media send
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Type caption alongside staged media (text field always visible) | VERIFIED | `message-input.tsx:192-198` (old `{!attachedFile && <Textarea/>}` guard removed) |
+| Coexistence model exactly as decided (reply/attachment/caption independent) | VERIFIED | `message-input.tsx` §2.3-2.4 logic; see §1.6 above |
+| Send delivers media+caption as one message; renders with media | VERIFIED | `conversation-view.tsx:365-417` (`sendMediaMessage(roomId, resourceId, caption, replyToId)`); `actions.ts:405-459`; Playwright `chat.spec.ts:159-195` |
+| Caption optional (empty behaves like media alone) | VERIFIED | `message-input.tsx:77` (`trimmed \|\| undefined`) |
+| Enter sends media+caption; Shift+Enter newline in caption | VERIFIED | `message-input.tsx:108-114` (same handler regardless of `hasFile`) |
+| Removing attachment retains caption as ordinary text | VERIFIED | `message-input.tsx:151-159` (`content` untouched) |
+| Caption shares 5,000-char limit, trimmed before send, over-limit disables Send + inline error | VERIFIED | `constants.ts:224` (`CHAT_MESSAGE_MAX_LENGTH`), `message-input.tsx:54-61,205-211`, `actions.ts:35-40` (server-side `sendMediaMessageSchema`, defense-in-depth); unit-tested `__tests__/[locale]/chat/actions.test.ts:736-746` |
+
+---
+
+## 3. Accessibility & Interaction Standards
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Every action keyboard-reachable (reply/edit/delete/jump-to-original/jump-to-latest/members/back) | VERIFIED | `message-actions-menu.tsx:35-51` (opacity-hidden via CSS only, still in tab order + `group-focus-within/message`); `reply-preview.tsx:48-57` (real `<button>`); `MessageScrollerButton` gets real button semantics (`inert`/`tabIndex` toggling) per compiled primitive source |
+| Incoming messages announced unobtrusively; day separators not announced as content | VERIFIED | Primitive: `Content` → `role="log" aria-relevant="additions"` (implicit polite live region), confirmed in `node_modules/@shadcn/react/dist/message-scroller/index.js`; `day-separator.tsx:41` `aria-hidden` |
+| `aria-busy` suppresses log announcements during older-history prepends | VERIFIED | `message-list.tsx:88-91` (`aria-busy={isLoadingOlder \|\| undefined}` on `MessageScrollerContent`) |
+| Reduced motion: reduced not removed, `behavior:"auto"` for all JS scrolls | VERIFIED | `use-prefers-reduced-motion.ts`; applied at `message-list.tsx:125,217`; CSS-only motion uses `motion-safe:`/`motion-reduce:` (`message-bubble.tsx:262`, `message-actions-menu.tsx:44`, `message-input.tsx:198`, `message-list.tsx:56`) |
+| Staging attachment doesn't force mobile keyboard; focus only from explicit action | VERIFIED | `message-input.tsx:143-146` (comment + no `.focus()` call) |
+| Paste always works in composer/caption | VERIFIED (by omission — no paste-blocking handler on the controlled `Textarea`) but **not explicitly covered by the manual checklist** | `message-input.tsx:181-188`; see Gaps §6 |
+| Locale-aware dates/times, no hardcoded shapes, stable across hydration | VERIFIED | `chat-utils.ts` (`Intl.DateTimeFormat`), `day-separator.tsx` (`useFormatter`), `member-list-panel.tsx` (`useFormatter().dateTime`); thread/members render only after client-side fetch (no SSR of message content), avoiding hydration mismatch by construction |
+| 44×44 touch targets (attach, per-message actions, back/members) | VERIFIED | `chat-attachment-menu.tsx:33` (`w-11`, h-60px), `message-actions-menu.tsx:44` (`size-11` mobile), `conversation-header.tsx:33,51` (`size-11`), `reply-preview.tsx:65-68` (`size-11`), `chat-attachment-preview.tsx:64` (`size-11`) |
+
+---
+
+## 4. Copy Conventions
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| All user-facing text localized; reuse unchanged wording | VERIFIED | `messages/en.json` diff; `member-list-panel.tsx` "(You)" hardcoded string replaced with `t("you")` |
+| 3 unlocalized loading strings fixed (conversation/load-older/room-list) | VERIFIED | Confirmed via diff: `conversation-view.tsx` `"Loading..."→t("loading.conversation")`; `message-list.tsx` `"Loading..."→t("loading.messages")`; `chat-room-list.tsx` `"Loading..."→t("loading.rooms")` |
+| Loading strings end in "…" not "..." | VERIFIED | `en.json`: `loading.conversation/messages/rooms`, `media.uploading` all use `…`. (Pre-existing, unrelated `message.placeholder: "Type a message..."` still uses literal dots — not a loading string, not touched by this PR, out of scope) |
+| New strings for Today/day-labels/caption-limit/original-not-available | VERIFIED | `en.json`: `thread.today`, `message.captionTooLong`/`messageTooLong`, `notices.originalNotAvailable` |
+| Title Case buttons/headings; numerals for counts | VERIFIED | "New Chat", "Jump to Latest", "Add Member", etc.; `selectedCount` uses `#` (numerals) |
+| Error copy states what happened + what user can do | VERIFIED | `errors.loadOlder`, `errors.sendDisabledRecover` |
+| Orphaned `chat.newMessages` key removed | VERIFIED | grep confirms zero references anywhere in `src`/`messages`/`tests` |
+
+---
+
+## 5. Mobile Expectations
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Single-pane nav + back affordance | VERIFIED (unchanged) | `chat-layout.tsx` mobile view toggling |
+| 44×44 touch targets (send/attach/actions/members/back) | VERIFIED | see §3 |
+| Composer visible above on-screen keyboard | MANUAL | checklist "Accessibility & mobile" |
+| Day separators/grouping/jump-to-latest same on mobile | VERIFIED (shared code path, no mobile branch) | `message-list.tsx`/`chat-thread-utils.ts` render unconditionally of viewport |
+| No tab-bar overlap regression | MANUAL (layout unchanged) | checklist "Accessibility & mobile" |
+
+---
+
+## 6. Validation Expectations — gaps found (severity-ranked)
+
+1. **MEDIUM — Baseline (self-triggered) inline-edit and delete+confirmation flows have no
+   automated coverage and no dedicated manual-checklist line item.** The pre-revamp Playwright
+   suite (`ce6443c:tests/pages/chat.spec.ts`) never covered these either, so this is not a new
+   regression in test coverage, but the requirements' "Manual pass across" list explicitly names
+   "inline edit; delete + confirmation" as required manual verification, and `message-bubble.tsx`'s
+   edit form and the delete-dialog wiring sit inside the anatomy that was substantially rewritten
+   (`Message`/`Bubble`/`BubbleContent`). The manual checklist only touches edit/delete in two other
+   contexts — remote-triggered abandon (`manual-checklist.md:16-17`) and keyboard-reachability
+   (`manual-checklist.md:71`) — never "I edit my own message and save/cancel it" or "I delete my own
+   message and confirm." Recommend adding one checklist line for each before merge.
+
+2. **LOW — Design's non-blocking CSS recommendation (§9) was only half-executed.**
+   `globals.css` adds `@utility scrollbar-thin`, `scrollbar-gutter-stable`,
+   `scrollbar-thumb-transparent`, `scrollbar-track-transparent` (used by
+   `message-scroller.tsx:45`), but `scroll-fade-b` (same line) and `scroll-fade-x`
+   (`attachment.tsx:189`) remain referenced, undefined Tailwind utility classes — Tailwind
+   generates no CSS for them, so the fade-mask affordance at the scroll edges is silently absent.
+   Purely cosmetic (native scrollbars, no fade mask), and the design doc explicitly allowed
+   "accept cosmetic degradation" as a valid choice — but the split (some utilities added, others
+   not) isn't called out anywhere, so it reads as an oversight rather than a decision.
+
+3. **LOW — Manual checklist omits a few requirements-listed items:** (a) "Pasting into the
+   composer and caption field always works" (Accessibility & Interaction Standards) has no
+   checklist line — low risk since the `Textarea` has no paste-blocking handler, but untested
+   either way; (b) the DM members panel's "no group-management controls" distinction isn't its
+   own checklist bullet (only implied); (c) sending a *video* specifically (vs. the
+   Playwright-covered image) isn't called out, though the composer code path is generic to any
+   accepted `File`.
+
+4. **INFO — Test organization deviates from the design's test plan (§11.2) without a
+   functional gap.** The two new capability specs were added as additional `test(...)` blocks
+   inside the existing `tests/pages/chat.spec.ts` rather than as the two separate files
+   (`chat-day-separator.spec.ts`, `chat-caption.spec.ts`) the design named. Coverage is present
+   and equivalent; this is purely organizational.
+
+5. **INFO — Playwright was not executed in this QA pass.** Per this verification's explicit
+   scope (build/lint/`npm test -- --run` only), `npx playwright test` was not run. Static review
+   confirms `tests/pages/chat.spec.ts` exercises: day-separator rendering + labels + send-still-
+   works, captioned-media send-and-render, and the same-day prepend no-scroll-jump assertion
+   (tolerance ≤100px) — matching the Validation Expectations. Recommend running
+   `npx playwright test --project=chromium tests/pages/chat.spec.ts` before merge if CI hasn't
+   already gone green on this branch.
+
+---
+
+## 7. Automated Green-State Verification
+
+### Build
+**PASS.** `npm run build` — compiled successfully, TypeScript check clean, all routes generated
+(including `/[locale]/chat`). Output: `/tmp/build-output.txt`.
+
+### Lint
+**PASS.** `npm run lint` — 0 errors. 1 pre-existing warning (`__tests__/components/playground/navbar.test.tsx:38`, unrelated to this PR — an unused eslint-disable directive). Output: `/tmp/lint-output.txt`.
+
+### Unit tests
+**PASS.** `npm test -- --run` — 52 files, 751 tests, all green, including the new
+`__tests__/components/chat/chat-thread-utils.test.ts` (21 tests: `localDayKey`, `classifyDayLabel`
+incl. cross-tz/local-midnight fixtures, `buildThreadItems` incl. midnight-spanning run and
+prepend-simulation, `reconcileMessages`, `hasReconnectGap`) and
+`__tests__/[locale]/chat/actions.test.ts` (server-action coverage incl. `sendMediaMessage`
+caption/replyToId argument shaping and the 5,000-char validation boundary). Timezone pinned via
+`vitest.config.mts` `test.env.TZ = "America/New_York"`. Output: `/tmp/vitest-output.txt`.
+
+### Playwright
+Not executed in this pass (see gap §6.5). Spec content statically reviewed and matches the
+Validation Expectations (two new-capability specs + the explicit prepend/no-jump assertion).
+
+---
+
+## 8. Overall Verdict
+
+**Ready for code review**, with the one medium-severity gap (§6.1) recommended to be closed
+(add two explicit manual-checklist lines for baseline inline-edit and delete+confirmation) before
+or during review, and the low/info items are worth a quick look but do not block. Build, lint, and
+the full unit-test suite are green; the feature-parity inventory and both new capabilities
+(day separators, media captions) are implemented and demonstrably match the requirements at the
+code level; the two WebSocket-dependent behaviors correctly remain MANUAL with checklist coverage
+for every item the requirements explicitly enumerate for that path.
+
+---
+
+## Addendum (post-QA resolution, same branch)
+
+- **Gap 1 (MEDIUM)** — resolved: the manual checklist gained a dedicated
+  "Message actions (baseline, self-triggered)" section covering inline edit
+  (save via Enter/button, cancel via Escape/button), delete + confirmation
+  (own, Owner/Admin on others, Member denied), paste into composer/caption,
+  and a video-specific send. (No automated coverage existed for these before
+  the revamp either — this is routed to the manual pass per the requirements.)
+- **Gap 2 (LOW)** — false positive: `scroll-fade-*` utilities are supplied by
+  the pre-existing `@import "shadcn/tailwind.css"` in globals.css, not defined
+  inline. Verified present in the production CSS bundle
+  (`.next/static/chunks/*.css` contains emitted rules for `scroll-fade-b`,
+  `scrollbar-thin`, and `shimmer`).
+- **Gap 3 (LOW)** — resolved: paste, DM members-panel no-group-controls, and
+  video send added to the checklist (see Gap 1 items and Cross-cutting).
+- **Gap 5 (INFO)** — satisfied: the full Playwright suite ran green in this
+  session (115 passed / 1 skipped), and the chat spec re-ran green (7/7) after
+  the post-review fixes in commit 56a092e.
+- Note: a parallel code review (7 findings, 1 critical) was fixed in commit
+  56a092e after this QA snapshot; line references in the tables above may be
+  slightly offset.

--- a/.claudedoc/chat-shadcn-revamp/requirements.md
+++ b/.claudedoc/chat-shadcn-revamp/requirements.md
@@ -1,0 +1,317 @@
+# Chat Revamp — Requirements
+
+## Overview
+
+The chat experience is being visually and structurally rebuilt on the project's
+new chat design system. This is a full front-of-house refresh: the conversation
+view, the message input, the room list, the members panel, and the create/direct-message
+dialogs all adopt the new look. Two new user-facing capabilities ship alongside the
+refresh: day separators in the message thread and the ability to add a caption when
+sending a photo or video.
+
+This is a single-PR effort. Every behavior that exists today must survive unless it is
+explicitly listed as changed below, and the two new capabilities must be present.
+
+## Goals
+
+- Give chat a cohesive, modern look consistent with the rest of the redesigned app.
+- Preserve the complete existing feature set — nothing users rely on today disappears.
+- Add day separators so long threads are easier to scan by date.
+- Let people caption media at the moment they send it (today they cannot).
+
+## Non-Goals (explicitly out of scope this iteration)
+
+- Message reactions (emoji on a message).
+- Link previews or auto-linkification of URLs in message text.
+- Typing / "is typing…" indicators.
+- Any change to who can chat with whom, how rooms are created, roles, or permissions.
+- Read receipts or per-message read state beyond the existing session-local unread dot.
+- Generic file upload from the composer (only images and videos can be sent today; that
+  limit is kept — see the composer inventory).
+- Profile-picture avatars in chat. Chat avatars remain initials-only, as today; real
+  profile pictures would require new fields on chat data and are a future iteration.
+- Backend/API changes. Both new capabilities are achievable client-side: the existing
+  send-media operation already accepts an optional caption and reply target, and day
+  separators derive from existing timestamps.
+
+## Users and Access
+
+- Chat is available only to authenticated users. Unauthenticated visitors are redirected
+  away, exactly as today.
+- Direct messages remain gated on a mutual-follow relationship. If two people no longer
+  follow each other, the conversation stays visible but sending is disabled with the
+  existing explanatory banner.
+- Group chats remain invite-only via the members panel; roles (Owner / Admin / Member)
+  govern who can add, remove, promote, demote, transfer ownership, and delete others'
+  messages.
+
+## Feature-Parity Inventory (must all survive the revamp)
+
+### Layout and navigation
+
+- Two-pane layout on desktop: room list on the left, active conversation on the right.
+- Empty right pane shows a "select or start a conversation" prompt when no room is open.
+- The open room is reflected in the URL so a conversation can be linked to / refreshed
+  into directly.
+
+### Room list
+
+- "New Chat" entry point at the top of the list.
+- Each room row shows: an avatar (initials), the room/person display name, a preview of
+  the last message, and a relative timestamp.
+- Last-message preview handles every message kind: text (truncated), image ("[Image]"),
+  file ("[File]"), a deleted message (shown in the deleted style), and system notes
+  (e.g. "X joined the chat").
+- Unread dot: reflects activity received during the current session while the room was
+  not open. It is session-local (not persisted across reloads, not server-backed read
+  state); opening the room clears it for the session. This matches today's behavior.
+- Rooms reorder to the top when they receive new activity.
+- Infinite scroll to load older rooms as the user scrolls.
+- Empty state when the user has no conversations, including a path to find people to
+  message.
+
+### Conversation header
+
+- Shows the room / other-person display name.
+- Members button opens the members panel.
+- Back affordance to return to the room list on mobile.
+
+### Message thread
+
+- Chronological thread (oldest at top, newest at bottom), paginated backward to load
+  older history. Auto-scrolls to the newest message on open and when a new message
+  arrives while the user is at the bottom.
+- When the user has scrolled up, a "jump to latest" affordance appears instead of yanking
+  them down; new activity does not force-scroll them.
+- Loads older messages as the user scrolls toward the top, preserving their scroll position
+  when older history is prepended (no visual jump).
+- Messages from the same sender in an unbroken run are grouped: the sender's identity
+  (avatar + name + time) shows once at the start of the run; subsequent messages are
+  visually attached, with their timestamp revealed on hover/focus.
+- Own messages and others' messages are visually distinguished and aligned per the new
+  design (see Visual Direction).
+- Message content types, all preserved:
+  - Text, with line breaks respected.
+  - Image — shown inline as a thumbnail that opens the full image.
+  - Video — inline player with controls.
+  - File — received file messages render as a file chip showing name and size with a
+    download affordance. (Files cannot be *sent* from the composer — see Non-Goals —
+    but must continue to render when received.)
+  - Media captions — when a media message has a caption, it displays with the media.
+- Replies: a message can quote the message it replies to, showing the original author and a
+  content snippet; tapping the quote jumps to the original in the thread and briefly
+  highlights it.
+  - The quoted snippet is a point-in-time copy. When the client knows the quoted message
+    was deleted (via a live event or loaded data), the snippet shows the deleted
+    placeholder; an unknowing stale snippet is acceptable.
+  - If the quoted original is not currently loaded in the thread, tapping the quote gives
+    clear feedback (a brief "original not available" notice) — never a silent no-op.
+    Auto-loading history until the original is found is not required this iteration.
+- Edited messages show an "edited" indicator.
+- Deleted messages show a "this message was deleted" placeholder in a muted/italic style,
+  in place of their original content.
+- System messages (member joined / member left) render as centered, non-bubble notices.
+
+### Message actions
+
+- Per-message action affordance (revealed on hover/focus) offering:
+  - Reply — available on any message.
+  - Edit — only on the user's own text messages.
+  - Delete — on the user's own messages, and on any message for Owners/Admins.
+- Delete asks for confirmation before removing.
+- Inline edit: editing happens in place with save/cancel; keyboard shortcuts (submit on
+  Enter, cancel on Escape) are preserved. Only text messages are editable.
+
+### Message input (composer)
+
+- Text composer with a placeholder; sends on Enter, inserts a newline on Shift+Enter.
+- Attachment entry point to pick a photo or video (today's accepted types and size limits
+  are kept).
+- Send affordance, with a busy/loading state while a message or upload is in flight.
+- Composer coexistence (changed from today, per the caption capability): the reply
+  preview, the attachment preview, and the text/caption field can all be visible at
+  once. Attaching media no longer clears an active reply. See New Capabilities §2 for
+  the full state model.
+- Reply composition: when replying, a dismissible preview of the quoted message sits above
+  the composer.
+- Attachment staging: a chosen file shows a pre-send preview (image thumbnail or a video
+  representation) with its name and size and a remove control.
+- File validation before send: unsupported types and oversized files are rejected with a
+  clear inline error, using the existing size/type limits.
+- When sending is disabled for a DM (mutual-follow lost), the composer is replaced by the
+  existing explanatory banner.
+
+### Members panel
+
+- Roster of members with name, role badge (in group chats), and joined date; the current
+  user is marked as "(You)".
+- Member names use the same display-name convention as the rest of chat; the joined date
+  uses app-locale-aware formatting (today it uses a different name helper and the browser
+  locale — align both during the revamp).
+- Add members via the mutual-follow picker (group chats only).
+- Remove a member, subject to role rules.
+- Promote to Admin / demote to Member (Owner only).
+- Transfer ownership (Owner → Admin), with confirmation; the previous owner becomes a
+  regular member.
+- Leave chat (non-owners), with confirmation; owners are told to transfer ownership first.
+- Direct-message rooms show the panel without the group-management controls.
+
+### Create / direct-message flow
+
+- New-chat picker over mutual follows.
+- Selecting exactly one person creates (or reopens) a direct message; the flow is idempotent
+  so it never creates duplicate DMs.
+- Selecting two or more people creates a group and requires a group name.
+- Mutual-follow requirement is enforced with a clear message when it isn't met.
+
+### Real-time behavior
+
+- Live updates via the existing subscription: incoming messages, edits, and deletions appear
+  without refresh; membership changes update the roster live.
+- Rooms surface unread state and reorder on new activity in real time.
+- On reconnect after a dropped connection, the room list and the open thread re-sync.
+  Re-syncing must not unmount or clear the composer (typed text, staged attachment,
+  caption, reply-in-progress all survive), must not force-scroll a user who was reading
+  older history, and reconciles new messages into the existing thread rather than
+  replacing the whole pane with a loading state.
+- If a message the viewer is currently inline-editing is deleted or updated by a
+  real-time event, the inline editor closes and the viewer sees a non-blocking notice;
+  the stale edit is abandoned, never silently applied.
+- The user's own just-sent message and its echoed real-time event never double-post.
+- Being removed from a room, or another member joining/leaving, is reflected immediately.
+
+### Error handling (preserve today's behavior, with two strengthenings)
+
+- Failures to load a room, load messages, send, edit, delete, create a room, or manage members
+  surface a clear, non-blocking notification; the app does not crash or lose the user's place.
+- A message that fails to send does not appear as sent.
+- Loss of the mutual-follow relationship discovered at send time flips the conversation into
+  the send-disabled state with its banner — but the just-attempted content must not be
+  silently destroyed: at minimum the attempted text is restated in the visible error so the
+  user can recover it.
+
+## New Capabilities
+
+### 1. Day separators in the thread
+
+- The message thread groups messages by calendar day. A slim, centered separator marks the
+  boundary between days.
+- The separator label is human-friendly and localized: "Today", "Yesterday", and an absolute
+  date for older days — locale-aware month + day (e.g. "March 3"), including the year when
+  it differs from the current year (e.g. "March 3, 2025").
+- A separator appears above the first message of each new day, including at the very top of
+  the loaded history. As older history is loaded above, separators continue to render
+  correctly for the newly revealed days.
+- A day boundary always breaks a sender-grouping run: the first message after any day
+  separator renders as the start of a new group (avatar + name + time shown), even when
+  the same sender wrote the message immediately before the separator.
+- System notices (joined/left) sit within their day like any other message and do not get
+  their own separators.
+- Separators are purely presentational — they are derived from existing message timestamps,
+  add no new data, and are not themselves selectable or actionable.
+- Day boundaries are computed in the viewer's local timezone: "Today" means the viewer's
+  today. Two viewers in different timezones may see the same message under different
+  day labels, and that is correct.
+- Relative labels ("Today"/"Yesterday") need not update live if the thread stays open
+  across midnight; refreshing on the next interaction or load is acceptable.
+
+### 2. Caption when sending media
+
+- When a user stages a photo or video to send, they can also type a caption in the same
+  composer before sending — the text field and the attachment preview coexist (today,
+  staging a file hides the text field, so captions are impossible on send).
+- Composer state model (decided): reply preview, attachment preview, and caption/text
+  field may all be present simultaneously. Attaching media while composing a reply keeps
+  the reply; sending delivers media + caption + reply target as one message. Dismissing
+  the reply preview removes only the reply; removing the attachment removes only the
+  attachment.
+- Sending delivers the media and its caption together as a single message; the caption then
+  displays beneath/with the media in the thread, exactly as captioned media already renders.
+- The caption is optional — sending with an empty caption behaves like sending media alone.
+- Pressing Enter with a staged attachment sends the media (with whatever caption is present);
+  Shift+Enter still inserts a newline in the caption.
+- Removing a staged attachment retains any typed caption as ordinary composer text.
+- The caption shares the text-message length limit (5,000 characters) and is trimmed of
+  incidental whitespace before sending. While media is staged, an over-limit caption
+  disables Send and shows an inline error (new localized string).
+
+## Visual Direction
+
+Adopt the new chat design system's look wholesale rather than re-skinning the current styling.
+Own vs. others' messages, bubble surfaces, avatars, grouping, attachments/file chips, and system
+notices should all follow the new system's default anatomy and styling. Where the new system's
+defaults differ from today's incidental styling (spacing, corner treatment, timestamp placement,
+hover affordances), prefer the new system's defaults. Chat avatars remain initials-only (see
+Non-Goals). The two constants that must not regress are (a) a clear visual distinction between
+the user's own messages and others', and (b) legibility and contrast in both light and dark
+themes. All new or moved user-facing text needs localized strings; reuse existing chat strings
+where the wording is unchanged.
+
+## Accessibility & Interaction Standards
+
+- Every message action (reply, edit, delete, jump-to-original, jump-to-latest, members,
+  back) is reachable and operable by keyboard, not only on hover.
+- Incoming messages are announced to screen readers unobtrusively (without stealing focus
+  or interrupting); day separators and other decorative elements are not announced as
+  content.
+- Motion (auto-scroll easing, the reply-highlight flash, separator/affordance transitions)
+  respects the user's reduced-motion preference: reduced or disabled, never removed
+  functionality.
+- Staging an attachment must not force the on-screen keyboard open on mobile; focus moves
+  to the caption field only from an explicit user action.
+- Pasting into the composer and caption field always works.
+- Dates, times, and relative labels use locale-aware formatting throughout — no hardcoded
+  date shapes — and render identically on first load and after hydration.
+
+## Copy Conventions
+
+- All user-facing text is localized; reuse existing chat strings where wording is unchanged.
+  Three currently-unlocalized loading strings must be localized during the revamp (the
+  conversation pane, the thread's load-older indicator, and the room list) — and new
+  strings are needed for "Today" and the day-separator labels, the caption over-limit
+  error, and the "original not available" reply-jump notice.
+- Loading states end with the ellipsis character ("Loading…", "Sending…") — "…", never "...".
+- Buttons and headings use Title Case; counts use numerals.
+- Error copy states what happened and what the user can do next, not just the problem.
+
+## Mobile Expectations
+
+- Preserve the current single-pane mobile model: the room list and the open conversation are
+  separate full-width views, with a back affordance returning from a conversation to the list.
+- All interactive controls (send, attach, per-message actions, members, back) present a
+  touch target of at least 44×44px. (Today's attach button is narrower — fix during the
+  revamp.)
+- With the on-screen keyboard open, the composer and its send control remain visible above
+  the keyboard, and staged-attachment + caption entry can be used without the thread being
+  fully obscured.
+- Day separators, message grouping, and the jump-to-latest affordance behave the same on mobile
+  as on desktop.
+- No regression to the existing page framing (the conversation area must not be overlapped by
+  app chrome such as the mobile tab bar).
+
+## Validation Expectations (single-PR rollout)
+
+Because this is a single PR touching the entire chat surface, validation must cover the full
+feature-parity inventory, not just the visual change:
+
+- Unit tests are required for the pure derivation logic: day-separator placement (including
+  midnight boundaries and sender runs spanning midnight), day-label selection
+  (Today / Yesterday / absolute date / year-qualified date), and message grouping.
+- Automated end-to-end: the existing Playwright chat coverage must pass. Assume the revamp
+  breaks essentially all chat selectors — plan for a full selector rewrite, not a patch.
+  Add coverage for the two new capabilities (a day separator appears at a day boundary; a
+  captioned media message can be sent and the caption renders).
+- Known harness limitation, acknowledged: WebSocket-driven behaviors (incoming messages,
+  live edit/delete, membership changes, unread/reorder, reconnect) are not covered by the
+  Playwright/MSW fetch-intercept harness. These are validated manually against a written
+  checklist covering: receive/edit/delete from a second participant, the editor-close-on-
+  remote-change rule, reconnect with an in-progress draft, unread + reordering, member
+  add/remove while the room is open, and no double-posting of own messages.
+- Manual pass across: sending/receiving text and each media type, captions on send (with and
+  without a reply), replies and jump-to-original (including a not-loaded original), inline
+  edit, delete + confirmation, grouping and day separators (including a midnight-spanning
+  run), the full members panel (add/remove/promote/demote/transfer/leave), DM
+  vs. group differences, the send-disabled DM banner with attempted-content
+  recovery, and the create-DM / create-group flows.
+- Both light and dark themes, and both desktop two-pane and mobile single-pane layouts.
+- Confirm no scroll jumps when older history loads.

--- a/__tests__/[locale]/chat/actions.test.ts
+++ b/__tests__/[locale]/chat/actions.test.ts
@@ -699,6 +699,52 @@ describe("sendMediaMessage", () => {
     expect(mediaArgs).toEqual({ chatRoomId: "room1", resourceId: "resource1" });
   });
 
+  it("includes caption and replyToId when provided", async () => {
+    mockMutateSuccess("sendChatMessage", "SendChatMessageResponse", {
+      chatMessage: mockChatMessage,
+    });
+
+    await sendMediaMessage("room1", "resource1", "A caption", "replyMsg1");
+
+    const callArg = mockAuthMutate.mock.calls[0][0] as Record<string, unknown>;
+    const mediaArgs = (
+      callArg.sendChatMessage as { __args: { input: { mediaMessage: Record<string, unknown> } } }
+    ).__args.input.mediaMessage;
+    expect(mediaArgs).toEqual({
+      chatRoomId: "room1",
+      resourceId: "resource1",
+      caption: "A caption",
+      replyToId: "replyMsg1",
+    });
+  });
+
+  it("omits caption and replyToId when not provided", async () => {
+    mockMutateSuccess("sendChatMessage", "SendChatMessageResponse", {
+      chatMessage: mockChatMessage,
+    });
+
+    await sendMediaMessage("room1", "resource1");
+
+    const callArg = mockAuthMutate.mock.calls[0][0] as Record<string, unknown>;
+    const mediaArgs = (
+      callArg.sendChatMessage as { __args: { input: { mediaMessage: Record<string, unknown> } } }
+    ).__args.input.mediaMessage;
+    expect(mediaArgs).not.toHaveProperty("caption");
+    expect(mediaArgs).not.toHaveProperty("replyToId");
+  });
+
+  it("returns VALIDATION_ERROR when caption exceeds 5000 chars without calling authMutate", async () => {
+    const longCaption = "a".repeat(5001);
+    const result = await sendMediaMessage("room1", "resource1", longCaption);
+
+    expect(result).toEqual({
+      success: false,
+      errorType: MutationErrorType.VALIDATION_ERROR,
+      message: expect.any(String),
+    });
+    expect(mockAuthMutate).not.toHaveBeenCalled();
+  });
+
   it("returns GRAPHQL_ERROR on top-level errors", async () => {
     mockMutateGraphqlError("Unauthorized");
 

--- a/__tests__/components/chat/chat-thread-utils.test.ts
+++ b/__tests__/components/chat/chat-thread-utils.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Timezone is pinned to America/New_York for this whole suite via
+ * `vitest.config.mts` (`test.env.TZ`) so `localDayKey`/`classifyDayLabel`
+ * (which use local `Date` methods) are deterministic in CI. Fixtures below
+ * are authored against that zone; dates are chosen to avoid DST transitions
+ * (America/New_York DST started 2025-03-09, so March 2–3 2025 is EST/UTC-5).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildThreadItems,
+  classifyDayLabel,
+  hasReconnectGap,
+  localDayKey,
+  reconcileMessages,
+} from "@/components/chat/chat-thread-utils";
+import type { Edge } from "@/lib/graphql-connection";
+import type {
+  ChatMessageNode,
+  ChatUser,
+  MemberJoinedChatMessageNode,
+  TextChatMessageNode,
+} from "@/lib/types/chat";
+
+function user(id: number): ChatUser {
+  return { id, firstName: null, lastName: null, displayName: `User ${id}` };
+}
+
+function textMessage(
+  id: string,
+  createdDate: string,
+  userId: number,
+  content = "hello",
+): TextChatMessageNode {
+  return {
+    __typename: "TextChatMessage",
+    id,
+    createdDate,
+    user: user(userId),
+    updatedDate: null,
+    deletedDate: null,
+    replyTo: null,
+    content,
+  };
+}
+
+function memberJoined(
+  id: string,
+  createdDate: string,
+  userId: number,
+): MemberJoinedChatMessageNode {
+  return {
+    __typename: "MemberJoinedChatMessage",
+    id,
+    createdDate,
+    member: user(userId),
+  };
+}
+
+function edge(node: ChatMessageNode): Edge<ChatMessageNode> {
+  return { cursor: node.id, node };
+}
+
+describe("localDayKey", () => {
+  it("buckets two timestamps on the same local day into the same key", () => {
+    expect(localDayKey("2025-06-15T14:00:00Z")).toBe(
+      localDayKey("2025-06-15T20:00:00Z"),
+    );
+  });
+
+  it("buckets timestamps across local midnight into different keys", () => {
+    // 2025-06-10T23:59 local (EDT, UTC-4) and 2025-06-11T00:01 local — 2
+    // minutes apart in real time, but different local calendar days.
+    const before = localDayKey("2025-06-11T03:59:00Z");
+    const after = localDayKey("2025-06-11T04:01:00Z");
+    expect(before).not.toBe(after);
+  });
+
+  it("buckets by local day even when the UTC day differs (cross-tz fixture)", () => {
+    // 2025-03-03T04:30:00Z is 2025-03-02T23:30 in America/New_York (EST).
+    expect(localDayKey("2025-03-03T04:30:00Z")).toBe(localDayKey("2025-03-02T12:00:00Z"));
+    expect(localDayKey("2025-03-03T04:30:00Z")).not.toBe(localDayKey("2025-03-03T12:00:00Z"));
+  });
+});
+
+describe("classifyDayLabel", () => {
+  const now = new Date("2025-06-15T16:00:00Z"); // 2025-06-15 12:00 local (EDT)
+
+  it("classifies a timestamp on the same local day as today", () => {
+    expect(classifyDayLabel("2025-06-15T20:00:00Z", now)).toEqual({
+      kind: "today",
+    });
+  });
+
+  it("classifies a timestamp on the previous local day as yesterday", () => {
+    expect(classifyDayLabel("2025-06-14T20:00:00Z", now)).toEqual({
+      kind: "yesterday",
+    });
+  });
+
+  it("classifies an older date in the current year without the year", () => {
+    // Cross-tz fixture: local day is 2025-03-02, same year as `now`.
+    expect(classifyDayLabel("2025-03-03T04:30:00Z", now)).toEqual({
+      kind: "date",
+      withYear: false,
+    });
+  });
+
+  it("classifies a date in a previous year with the year", () => {
+    expect(classifyDayLabel("2024-06-15T20:00:00Z", now)).toEqual({
+      kind: "date",
+      withYear: true,
+    });
+  });
+
+  it("resolves local-midnight boundaries using local days, not UTC days", () => {
+    // `now` is 2025-06-14 23:00 local (crosses into 2025-06-15 in UTC).
+    const nowNearLocalMidnight = new Date("2025-06-15T03:00:00Z");
+
+    // Same local day as `now` (2025-06-14), despite being on the previous
+    // UTC calendar day.
+    expect(
+      classifyDayLabel("2025-06-14T05:00:00Z", nowNearLocalMidnight),
+    ).toEqual({ kind: "today" });
+
+    // Previous local day (2025-06-13).
+    expect(
+      classifyDayLabel("2025-06-13T22:00:00Z", nowNearLocalMidnight),
+    ).toEqual({ kind: "yesterday" });
+  });
+});
+
+describe("buildThreadItems", () => {
+  it("flags only the first message of a single day as isDayStart", () => {
+    const messages = [
+      textMessage("m1", "2025-06-15T14:00:00Z", 1),
+      textMessage("m2", "2025-06-15T14:01:00Z", 1), // same sender, <5min → grouped
+      textMessage("m3", "2025-06-15T14:02:00Z", 2), // different sender → group start
+    ];
+
+    const items = buildThreadItems(messages);
+
+    expect(items).toHaveLength(messages.length);
+    expect(items.map((i) => i.isDayStart)).toEqual([true, false, false]);
+    expect(items.map((i) => i.isGroupStart)).toEqual([true, false, true]);
+  });
+
+  it("marks the first item of a second day as both isDayStart and isGroupStart", () => {
+    const messages = [
+      textMessage("m1", "2025-06-15T14:00:00Z", 1),
+      textMessage("m2", "2025-06-15T14:01:00Z", 1),
+      textMessage("m3", "2025-06-16T14:00:00Z", 1),
+    ];
+
+    const items = buildThreadItems(messages);
+
+    expect(items[2].isDayStart).toBe(true);
+    expect(items[2].isGroupStart).toBe(true);
+  });
+
+  it("breaks a same-sender run at midnight even within the 5-minute grouping window", () => {
+    // 2025-06-10 23:59 local and 2025-06-11 00:01 local — 2 minutes apart,
+    // same sender, but a day boundary sits between them.
+    const messages = [
+      textMessage("m1", "2025-06-11T03:59:00Z", 1),
+      textMessage("m2", "2025-06-11T04:01:00Z", 1),
+    ];
+
+    const items = buildThreadItems(messages);
+
+    expect(items[0].dayKey).not.toBe(items[1].dayKey);
+    expect(items[1].isDayStart).toBe(true);
+    expect(items[1].isGroupStart).toBe(true);
+  });
+
+  it("buckets a message by local day even when its UTC day differs", () => {
+    const messages = [
+      textMessage("m1", "2025-03-02T12:00:00Z", 1),
+      // Local day 2025-03-02 (EST) despite the 03-03 UTC date.
+      textMessage("m2", "2025-03-03T04:30:00Z", 1),
+    ];
+
+    const items = buildThreadItems(messages);
+
+    expect(items[0].dayKey).toBe(items[1].dayKey);
+    expect(items[1].isDayStart).toBe(false);
+  });
+
+  it("lets a system notice break the run without giving it its own separator", () => {
+    const messages: ChatMessageNode[] = [
+      textMessage("m1", "2025-06-15T14:00:00Z", 1),
+      memberJoined("m2", "2025-06-15T14:01:00Z", 2),
+      textMessage("m3", "2025-06-15T14:02:00Z", 1),
+    ];
+
+    const items = buildThreadItems(messages);
+
+    expect(items.map((i) => i.isDayStart)).toEqual([true, false, false]);
+    // The system notice breaks grouping for itself and the message after it.
+    expect(items.map((i) => i.isGroupStart)).toEqual([true, true, true]);
+  });
+
+  it("recomputes isDayStart correctly across the full array when older history is prepended", () => {
+    const day2Only = [
+      textMessage("m3", "2025-06-16T14:00:00Z", 1),
+      textMessage("m4", "2025-06-16T14:01:00Z", 1),
+    ];
+    const itemsBefore = buildThreadItems(day2Only);
+    expect(itemsBefore[0].isDayStart).toBe(true);
+
+    // Simulate an older-history prepend: day 1 messages are added ahead of
+    // the already-loaded day 2 messages.
+    const withOlderDayPrepended = [
+      textMessage("m1", "2025-06-15T14:00:00Z", 1),
+      textMessage("m2", "2025-06-15T14:01:00Z", 1),
+      ...day2Only,
+    ];
+    const itemsAfter = buildThreadItems(withOlderDayPrepended);
+
+    expect(itemsAfter[0].isDayStart).toBe(true); // revealed day 1 start
+    expect(itemsAfter[2].isDayStart).toBe(true); // day 2 start still correct
+  });
+});
+
+describe("reconcileMessages", () => {
+  it("upserts a changed node (edit/delete) in place", () => {
+    const prev = [
+      edge(textMessage("m1", "2025-06-15T14:00:00Z", 1, "original")),
+      edge(textMessage("m2", "2025-06-15T14:01:00Z", 1, "second")),
+    ];
+    const editedM1 = textMessage("m1", "2025-06-15T14:00:00Z", 1, "edited");
+    const incoming = [edge(editedM1)];
+
+    const result = reconcileMessages(prev, incoming);
+
+    expect(result).toHaveLength(2);
+    const m1 = result.find((e) => e.node.id === "m1");
+    expect((m1?.node as TextChatMessageNode).content).toBe("edited");
+  });
+
+  it("inserts a new tail message in sorted position", () => {
+    const prev = [
+      edge(textMessage("m1", "2025-06-15T14:00:00Z", 1)),
+      edge(textMessage("m2", "2025-06-15T14:01:00Z", 1)),
+    ];
+    const incoming = [
+      edge(textMessage("m2", "2025-06-15T14:01:00Z", 1)),
+      edge(textMessage("m3", "2025-06-15T14:02:00Z", 1)),
+    ];
+
+    const result = reconcileMessages(prev, incoming);
+
+    expect(result.map((e) => e.node.id)).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("retains older loaded history not present in the incoming window", () => {
+    const prev = [
+      edge(textMessage("m0", "2025-06-14T14:00:00Z", 1)), // older, not in incoming
+      edge(textMessage("m1", "2025-06-15T14:00:00Z", 1)),
+    ];
+    const incoming = [edge(textMessage("m1", "2025-06-15T14:00:00Z", 1))];
+
+    const result = reconcileMessages(prev, incoming);
+
+    expect(result.map((e) => e.node.id)).toEqual(["m0", "m1"]);
+  });
+
+  it("dedups by id when the same message appears in both prev and incoming", () => {
+    const m1 = textMessage("m1", "2025-06-15T14:00:00Z", 1);
+    const result = reconcileMessages([edge(m1)], [edge(m1)]);
+
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("hasReconnectGap", () => {
+  it("is false when there is no prior or no incoming history", () => {
+    const someEdge = edge(textMessage("m1", "2025-06-15T14:00:00Z", 1));
+    expect(hasReconnectGap([], [someEdge])).toBe(false);
+    expect(hasReconnectGap([someEdge], [])).toBe(false);
+  });
+
+  it("is false when the incoming window overlaps the retained tail", () => {
+    const prev = [edge(textMessage("m1", "2025-06-15T14:00:00Z", 1))];
+    const incoming = [
+      edge(textMessage("m1", "2025-06-15T14:00:00Z", 1)),
+      edge(textMessage("m2", "2025-06-15T14:05:00Z", 1)),
+    ];
+
+    expect(hasReconnectGap(prev, incoming)).toBe(false);
+  });
+
+  it("is true when the incoming window's oldest message is strictly newer than the retained tail's newest", () => {
+    const prev = [edge(textMessage("m1", "2025-06-15T14:00:00Z", 1))];
+    const incoming = [edge(textMessage("m2", "2025-06-15T15:00:00Z", 1))];
+
+    expect(hasReconnectGap(prev, incoming)).toBe(true);
+  });
+});

--- a/messages/en.json
+++ b/messages/en.json
@@ -882,7 +882,16 @@
     "mutualFollowRequired": "Mutual follow required to send messages",
     "createRoom": "Create",
     "back": "Back",
-    "newMessages": "New messages",
+    "thread": {
+      "today": "Today",
+      "ariaLabel": "Messages",
+      "jumpToLatest": "Jump to Latest"
+    },
+    "loading": {
+      "conversation": "Loading conversation…",
+      "messages": "Loading messages…",
+      "rooms": "Loading conversations…"
+    },
     "message": {
       "placeholder": "Type a message...",
       "send": "Send",
@@ -895,7 +904,14 @@
       "save": "Save",
       "cancel": "Cancel",
       "imageAttachment": "[Image]",
-      "fileAttachment": "[File]"
+      "fileAttachment": "[File]",
+      "captionPlaceholder": "Add a caption…",
+      "captionTooLong": "Caption is too long. Keep it under {limit} characters.",
+      "messageTooLong": "Message is too long. Keep it under {limit} characters."
+    },
+    "notices": {
+      "originalNotAvailable": "That message isn't loaded yet. Scroll up to find it.",
+      "editingInterrupted": "This message changed, so your edit wasn't saved."
     },
     "members": {
       "title": "Members",
@@ -952,7 +968,10 @@
       "removeMember": "Failed to remove member",
       "roomNotFound": "Conversation not found",
       "updateRole": "Failed to update role",
-      "leaveChat": "Failed to leave chat"
+      "leaveChat": "Failed to leave chat",
+      "loadOlder": "Couldn't load older messages. Scroll up to try again.",
+      "sendDisabledRecover": "You can no longer message this person. Your unsent message: \"{content}\"",
+      "sendDisabledMedia": "You can no longer message this person, so your photo or video wasn't sent."
     },
     "time": {
       "justNow": "Just now",

--- a/messages/en.json
+++ b/messages/en.json
@@ -907,7 +907,9 @@
       "fileAttachment": "[File]",
       "captionPlaceholder": "Add a caption…",
       "captionTooLong": "Caption is too long. Keep it under {limit} characters.",
-      "messageTooLong": "Message is too long. Keep it under {limit} characters."
+      "messageTooLong": "Message is too long. Keep it under {limit} characters.",
+      "removeReply": "Remove reply",
+      "moreActions": "More options"
     },
     "notices": {
       "originalNotAvailable": "That message isn't loaded yet. Scroll up to find it.",
@@ -915,6 +917,7 @@
     },
     "members": {
       "title": "Members",
+      "you": "You",
       "add": "Add Member",
       "remove": "Remove",
       "removeConfirm": "Are you sure you want to remove {name} from this chat?",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
+        "@shadcn/react": "^0.2.1",
         "@tanstack/react-devtools": "^0.9.4",
         "@tanstack/react-form": "^1.28.0",
         "@tanstack/react-form-devtools": "^0.2.13",
@@ -3487,6 +3488,24 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
+    },
+    "node_modules/@shadcn/react": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@shadcn/react/-/react-0.2.1.tgz",
+      "integrity": "sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=19",
+        "react": ">=19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@shadcn/react": "^0.2.1",
     "@tanstack/react-devtools": "^0.9.4",
     "@tanstack/react-form": "^1.28.0",
     "@tanstack/react-form-devtools": "^0.2.13",

--- a/src/app/[locale]/chat/actions.ts
+++ b/src/app/[locale]/chat/actions.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/graphql-fragments";
 import { authMutate, authQuery } from "@/lib/graphql-request";
 import { extractMutationResult, MutationErrorType } from "@/lib/graphql-result";
+import { CHAT_MESSAGE_MAX_LENGTH } from "@/lib/constants";
 import type {
   ChatMessageNode,
   ChatRoomDetailNode,
@@ -22,13 +23,20 @@ import { z } from "zod";
 
 const sendMessageSchema = z.object({
   chatRoomId: z.string().min(1),
-  content: z.string().min(1).max(5000),
+  content: z.string().min(1).max(CHAT_MESSAGE_MAX_LENGTH),
   replyToId: z.string().min(1).optional(),
 });
 
 const updateMessageSchema = z.object({
   id: z.string().min(1),
-  content: z.string().min(1).max(5000),
+  content: z.string().min(1).max(CHAT_MESSAGE_MAX_LENGTH),
+});
+
+const sendMediaMessageSchema = z.object({
+  chatRoomId: z.string().min(1),
+  resourceId: z.string().min(1),
+  caption: z.string().max(CHAT_MESSAGE_MAX_LENGTH).optional(),
+  replyToId: z.string().min(1).optional(),
 });
 
 const createDirectMessageSchema = z.object({
@@ -397,20 +405,34 @@ export async function sendMessage(
 export async function sendMediaMessage(
   chatRoomId: string,
   resourceId: string,
+  caption?: string,
+  replyToId?: string,
 ): Promise<{
   success: boolean;
   chatMessage?: ChatMessageNode;
   errorType?: string;
   message?: string;
 }> {
+  const parsed = sendMediaMessageSchema.safeParse({
+    chatRoomId,
+    resourceId,
+    caption,
+    replyToId,
+  });
+  if (!parsed.success) {
+    return { success: false, errorType: MutationErrorType.VALIDATION_ERROR, message: parsed.error.issues[0].message };
+  }
+
   try {
     const response = await authMutate({
       sendChatMessage: {
         __args: {
           input: {
             mediaMessage: {
-              chatRoomId,
-              resourceId,
+              chatRoomId: parsed.data.chatRoomId,
+              resourceId: parsed.data.resourceId,
+              ...(parsed.data.caption ? { caption: parsed.data.caption } : {}),
+              ...(parsed.data.replyToId ? { replyToId: parsed.data.replyToId } : {}),
             },
           },
         },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -266,6 +266,43 @@
   100% { background-color: var(--secondary); }
 }
 
+/* Scrollbar utilities referenced by message-scroller.tsx's Viewport (the
+   registry component ships classes for these but not the CSS behind them).
+   Composable via CSS custom properties so `scrollbar-thumb-transparent` /
+   `scrollbar-track-transparent` can be layered on top of `scrollbar-thin`
+   behind a data-attribute variant (e.g. `data-autoscrolling:`). */
+@utility scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb-color, var(--border))
+    var(--scrollbar-track-color, transparent);
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: var(--scrollbar-track-color, transparent);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb-color, var(--border));
+    border-radius: 9999px;
+  }
+}
+
+@utility scrollbar-gutter-stable {
+  scrollbar-gutter: stable;
+}
+
+@utility scrollbar-thumb-transparent {
+  --scrollbar-thumb-color: transparent;
+}
+
+@utility scrollbar-track-transparent {
+  --scrollbar-track-color: transparent;
+}
+
 @keyframes ptr-bounce {
   0%, 80%, 100% { transform: translateY(0); }
   40% { transform: translateY(-4px); }

--- a/src/components/chat/chat-attachment-menu.tsx
+++ b/src/components/chat/chat-attachment-menu.tsx
@@ -30,7 +30,7 @@ export function ChatAttachmentMenu({
       <Button
         variant="ghost"
         size="icon"
-        className="h-[60px] w-10 shrink-0"
+        className="h-[60px] w-11 shrink-0"
         disabled={disabled}
         aria-label={t("attachFile")}
         onClick={() => fileInputRef.current?.click()}

--- a/src/components/chat/chat-attachment-preview.tsx
+++ b/src/components/chat/chat-attachment-preview.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import {
+  Attachment,
+  AttachmentAction,
+  AttachmentActions,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentMedia,
+  AttachmentTitle,
+} from "@/components/ui/attachment";
 import { formatFileSize } from "@/lib/upload-validation";
 import { Film, X } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -10,6 +18,7 @@ interface ChatAttachmentPreviewProps {
   previewUrl: string | null;
   error: string | null;
   onRemove: () => void;
+  disabled?: boolean;
 }
 
 export function ChatAttachmentPreview({
@@ -17,38 +26,49 @@ export function ChatAttachmentPreview({
   previewUrl,
   error,
   onRemove,
+  disabled,
 }: ChatAttachmentPreviewProps) {
   const t = useTranslations("chat.media");
   const isImage = file.type.startsWith("image/");
+  const showImagePreview = isImage && previewUrl;
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border bg-muted/50 p-3">
-      <div className="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-md border">
-        {isImage && previewUrl ? (
+    <Attachment state={error ? "error" : "idle"}>
+      <AttachmentMedia variant={showImagePreview ? "image" : "icon"}>
+        {showImagePreview ? (
           // eslint-disable-next-line @next/next/no-img-element -- previewUrl is a blob: URL for an unsaved local file, which next/image cannot handle
-          <img src={previewUrl} alt="" className="h-full w-full object-cover" />
+          <img
+            src={previewUrl}
+            alt=""
+            className="h-full w-full object-cover"
+          />
         ) : (
-          <Film className="h-6 w-6 text-muted-foreground" />
+          <Film />
         )}
-      </div>
+      </AttachmentMedia>
 
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium">{file.name}</div>
-        <div className="text-xs text-muted-foreground">
+      <AttachmentContent>
+        <AttachmentTitle>{file.name}</AttachmentTitle>
+        <AttachmentDescription>
           {formatFileSize(file.size)}
-        </div>
-        {error && <div className="text-xs text-destructive">{error}</div>}
-      </div>
+        </AttachmentDescription>
+        {error && (
+          <AttachmentDescription className="text-destructive">
+            {error}
+          </AttachmentDescription>
+        )}
+      </AttachmentContent>
 
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-8 w-8 shrink-0"
-        onClick={onRemove}
-        aria-label={t("removeAttachment")}
-      >
-        <X className="h-4 w-4" />
-      </Button>
-    </div>
+      <AttachmentActions>
+        <AttachmentAction
+          className="size-11"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label={t("removeAttachment")}
+        >
+          <X />
+        </AttachmentAction>
+      </AttachmentActions>
+    </Attachment>
   );
 }

--- a/src/components/chat/chat-room-list-item.tsx
+++ b/src/components/chat/chat-room-list-item.tsx
@@ -5,7 +5,7 @@ import {
   getChatRoomDisplayName,
 } from "@/components/chat/chat-utils";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { TypographyMuted } from "@/components/ui/typography";
+import { TypographyMuted, TypographySmall } from "@/components/ui/typography";
 import type { ChatRoomListNode } from "@/lib/types/chat";
 import { isUserChatMessage } from "@/lib/types/chat-guards";
 import { cn } from "@/lib/utils";
@@ -63,7 +63,7 @@ export function ChatRoomListItem({
         const content = lastMessage.content;
         if (content) {
           lastMessagePreview =
-            content.length > 50 ? content.substring(0, 50) + "..." : content;
+            content.length > 50 ? `${content.substring(0, 50)}…` : content;
         }
       } else if (lastMessage.__typename === "MediaChatMessage") {
         if (lastMessage.resource.__typename === "ImageResource") {
@@ -97,7 +97,9 @@ export function ChatRoomListItem({
 
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline justify-between gap-2 mb-1">
-          <h3 className="font-semibold text-sm truncate">{displayName}</h3>
+          <TypographySmall as="h3" className="truncate font-semibold">
+            {displayName}
+          </TypographySmall>
           <div className="flex items-center gap-1.5 shrink-0">
             {lastMessageTime && (
               <span className="text-xs text-muted-foreground">

--- a/src/components/chat/chat-room-list.tsx
+++ b/src/components/chat/chat-room-list.tsx
@@ -230,7 +230,7 @@ export function ChatRoomList({
 
           {isLoading && (
             <div className="p-4 text-center">
-              <TypographyMuted>Loading...</TypographyMuted>
+              <TypographyMuted>{t("loading.rooms")}</TypographyMuted>
             </div>
           )}
         </div>

--- a/src/components/chat/chat-thread-utils.ts
+++ b/src/components/chat/chat-thread-utils.ts
@@ -1,0 +1,126 @@
+import type { Edge } from "@/lib/graphql-connection";
+import type { ChatMessageNode } from "@/lib/types/chat";
+import { shouldShowSender } from "./chat-utils";
+
+/** Local-timezone calendar-day bucket, formatted "YYYY-MM-DD". */
+export type DayKey = string;
+
+/**
+ * One render row. Day separators are NOT separate items — they render
+ * inside the first item of a day (see `isDayStart`).
+ */
+export interface MessageThreadItem {
+  message: ChatMessageNode;
+  /** Avatar + name + time shown (forced true after a day boundary). */
+  isGroupStart: boolean;
+  /** Render the day Marker above this item. */
+  isDayStart: boolean;
+  dayKey: DayKey;
+  /** === message.createdDate; used only to derive the day label. */
+  dayTimestamp: string;
+}
+
+/** Alias kept for readability at call sites. */
+export type ThreadItem = MessageThreadItem;
+
+function dayKeyFromDate(d: Date): DayKey {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Local-timezone calendar-day bucket (uses local getFullYear/getMonth/getDate
+ * → viewer tz). Different-timezone viewers may bucket the same message
+ * differently, by design — "Today" means the viewer's today.
+ */
+export function localDayKey(iso: string): DayKey {
+  return dayKeyFromDate(new Date(iso));
+}
+
+/**
+ * Pure. `messages` MUST be ascending by createdDate. Emits one item per
+ * message; the first message of each local day carries isDayStart=true (its
+ * item renders the day Marker). A day boundary always forces
+ * isGroupStart=true. System notices participate in grouping (they break runs
+ * via shouldShowSender) but never get their own separator.
+ */
+export function buildThreadItems(
+  messages: ChatMessageNode[],
+): MessageThreadItem[] {
+  const items: MessageThreadItem[] = [];
+  let prevDayKey: DayKey | null = null;
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const dayKey = localDayKey(message.createdDate);
+    const isDayStart = dayKey !== prevDayKey;
+    const isGroupStart = isDayStart || shouldShowSender(messages, i);
+    items.push({
+      message,
+      isGroupStart,
+      isDayStart,
+      dayKey,
+      dayTimestamp: message.createdDate,
+    });
+    prevDayKey = dayKey;
+  }
+  return items;
+}
+
+export type DayLabelKind =
+  | { kind: "today" }
+  | { kind: "yesterday" }
+  | { kind: "date"; withYear: boolean };
+
+/**
+ * Pure. Classifies `timestamp`'s local day relative to `now`'s local day.
+ * Never reads the wall clock directly — callers supply `now` (e.g. via
+ * `useNow()`), which keeps this testable and avoids SSR/client drift.
+ */
+export function classifyDayLabel(timestamp: string, now: Date): DayLabelKind {
+  const date = new Date(timestamp);
+  const dayKey = dayKeyFromDate(date);
+
+  if (dayKey === dayKeyFromDate(now)) return { kind: "today" };
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (dayKey === dayKeyFromDate(yesterday)) return { kind: "yesterday" };
+
+  return { kind: "date", withYear: date.getFullYear() !== now.getFullYear() };
+}
+
+/**
+ * Pure. Merge the recent window into the existing thread by id; keep older
+ * loaded history; sort ascending by createdDate.
+ */
+export function reconcileMessages(
+  prev: Edge<ChatMessageNode>[],
+  incoming: Edge<ChatMessageNode>[],
+): Edge<ChatMessageNode>[] {
+  const byId = new Map(prev.map((e) => [e.node.id, e]));
+  for (const e of incoming) byId.set(e.node.id, e);
+  return [...byId.values()].sort(
+    (a, b) =>
+      new Date(a.node.createdDate).getTime() -
+      new Date(b.node.createdDate).getTime(),
+  );
+}
+
+/**
+ * Pure. True when the newest window does NOT overlap the retained tail (a
+ * gap of more than a page of messages arrived while offline). Strict
+ * inequality: no overlap means a middle gap exists that cannot be silently
+ * stitched.
+ */
+export function hasReconnectGap(
+  prev: Edge<ChatMessageNode>[],
+  incoming: Edge<ChatMessageNode>[],
+): boolean {
+  if (prev.length === 0 || incoming.length === 0) return false;
+  const retainedNewest = Math.max(
+    ...prev.map((e) => new Date(e.node.createdDate).getTime()),
+  );
+  const incomingOldest = Math.min(
+    ...incoming.map((e) => new Date(e.node.createdDate).getTime()),
+  );
+  return incomingOldest > retainedNewest;
+}

--- a/src/components/chat/chat-thread-utils.ts
+++ b/src/components/chat/chat-thread-utils.ts
@@ -20,9 +20,6 @@ export interface MessageThreadItem {
   dayTimestamp: string;
 }
 
-/** Alias kept for readability at call sites. */
-export type ThreadItem = MessageThreadItem;
-
 function dayKeyFromDate(d: Date): DayKey {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }

--- a/src/components/chat/conversation-header.tsx
+++ b/src/components/chat/conversation-header.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { TypographyH5 } from "@/components/ui/typography";
 import type { ChatRoomDetailNode } from "@/lib/types/chat";
 import { ArrowLeft, Users } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { getChatRoomDisplayName } from "./chat-utils";
 
 interface ConversationHeaderProps {
@@ -18,27 +20,38 @@ export function ConversationHeader({
   onToggleMembers,
   onBack,
 }: ConversationHeaderProps) {
+  const t = useTranslations("chat");
+  const tMembers = useTranslations("chat.members");
   const displayName = getChatRoomDisplayName(room, currentUserId);
 
   return (
     <div className="flex items-center gap-3 border-b bg-background px-4 py-3">
-      {/* Back button - visible on mobile only */}
+      {/* Back button - visible on mobile only; ≥44px touch target */}
       <Button
         variant="ghost"
         size="icon"
-        className="md:hidden"
+        className="size-11 shrink-0 md:hidden"
         onClick={onBack}
+        aria-label={t("back")}
       >
         <ArrowLeft className="h-5 w-5" />
       </Button>
 
       {/* Room name */}
       <div className="flex-1 truncate">
-        <h2 className="truncate text-lg font-semibold">{displayName}</h2>
+        <TypographyH5 as="h2" className="truncate">
+          {displayName}
+        </TypographyH5>
       </div>
 
-      {/* Members button */}
-      <Button variant="ghost" size="icon" onClick={onToggleMembers}>
+      {/* Members button — ≥44px touch target on mobile */}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-11 shrink-0 md:size-9"
+        onClick={onToggleMembers}
+        aria-label={tMembers("title")}
+      >
         <Users className="h-5 w-5" />
       </Button>
     </div>

--- a/src/components/chat/conversation-view.tsx
+++ b/src/components/chat/conversation-view.tsx
@@ -342,7 +342,12 @@ export function ConversationView({
             if (didUserMessageChange(prevById.get(editingId), next)) {
               abandonEdit();
             }
-          } else if (gap) {
+          } else if (gap && prevById.has(editingId)) {
+            // Absent from the fresh window AND present before the fetch →
+            // genuinely dropped by the gap reset. A message absent from
+            // prevById arrived DURING the fetch (optimistic send / echo),
+            // survives the retained-set filter above, and must not have its
+            // fresh edit spuriously abandoned.
             abandonEdit();
           }
         }
@@ -499,7 +504,7 @@ export function ConversationView({
     setIsDeleting(false);
   };
 
-  /** Resolves to false only on an actual fetch failure (so the list can toast + re-arm the trigger). A guarded no-op (already loading / no more pages) resolves true. */
+  /** Resolves to false only on an actual fetch failure (the list toasts; retry is the user's natural scroll-away/scroll-back — deliberately NO automatic re-arm, which looped unboundedly). A guarded no-op (already loading / no more pages) resolves true. */
   const handleLoadOlder = async (): Promise<boolean> => {
     if (!messagesPageInfo?.hasPreviousPage || isLoadingOlder) return true;
 

--- a/src/components/chat/conversation-view.tsx
+++ b/src/components/chat/conversation-view.tsx
@@ -43,7 +43,6 @@ interface ConversationViewProps {
   reconnectCounter: number;
 }
 
-/** True when the edited message's node changed (or vanished) — closes the editor rather than risk silently applying a stale edit. */
 /**
  * Insert an edge maintaining ascending createdDate order — buildThreadItems
  * requires it, and every producer (incoming events, optimistic sends,
@@ -67,6 +66,32 @@ function insertEdgeSorted(
   return next;
 }
 
+/**
+ * Returns a new list with `message` inserted in sorted position, or `prev`
+ * unchanged when the id is already present — the dedup every producer needs
+ * because the WebSocket echo and the mutation response race each other.
+ */
+function appendMessage(
+  prev: Edge<ChatMessageNode>[],
+  message: ChatMessageNode,
+): Edge<ChatMessageNode>[] {
+  if (prev.some((edge) => edge.node.id === message.id)) {
+    return prev;
+  }
+  return insertEdgeSorted(prev, { cursor: message.id, node: message });
+}
+
+/** Returns a new list with an already-loaded message's node swapped for `message`. */
+function replaceMessageNode(
+  prev: Edge<ChatMessageNode>[],
+  message: ChatMessageNode,
+): Edge<ChatMessageNode>[] {
+  return prev.map((edge) =>
+    edge.node.id === message.id ? { ...edge, node: message } : edge,
+  );
+}
+
+/** True when the edited message's node changed (or vanished) — closes the editor rather than risk silently applying a stale edit. */
 function didUserMessageChange(
   prev: ChatMessageNode | undefined,
   next: ChatMessageNode,
@@ -138,31 +163,12 @@ export function ConversationView({
   }, [t]);
 
   const handleIncomingMessage = useCallback((message: ChatMessageNode) => {
-    setMessages((prev) => {
-      // Self-event deduplication: skip if message already exists
-      if (prev.some((edge) => edge.node.id === message.id)) {
-        return prev;
-      }
-
-      const newEdge: Edge<ChatMessageNode> = {
-        cursor: message.id,
-        node: message,
-      };
-
-      return insertEdgeSorted(prev, newEdge);
-    });
+    setMessages((prev) => appendMessage(prev, message));
   }, []);
 
   const handleIncomingUpdate = useCallback(
     (message: ChatMessageNode) => {
-      setMessages((prev) =>
-        prev.map((edge) => {
-          if (edge.node.id === message.id) {
-            return { ...edge, node: message };
-          }
-          return edge;
-        }),
-      );
+      setMessages((prev) => replaceMessageNode(prev, message));
       if (message.id === editingMessageIdRef.current) abandonEdit();
     },
     [abandonEdit],
@@ -170,14 +176,7 @@ export function ConversationView({
 
   const handleIncomingDelete = useCallback(
     (message: ChatMessageNode) => {
-      setMessages((prev) =>
-        prev.map((edge) => {
-          if (edge.node.id === message.id) {
-            return { ...edge, node: message };
-          }
-          return edge;
-        }),
-      );
+      setMessages((prev) => replaceMessageNode(prev, message));
       if (message.id === editingMessageIdRef.current) abandonEdit();
       // Propagate the deletion into the composer's reply-in-progress, if any.
       setReplyTo((r) =>
@@ -383,21 +382,11 @@ export function ConversationView({
       throw new Error("Failed to send message");
     }
 
-    // Append the new message, but deduplicate in case the WebSocket event
-    // arrived before the mutation response
-    const newEdge: Edge<ChatMessageNode> = {
-      cursor: result.chatMessage.id,
-      node: result.chatMessage,
-    };
-    setMessages((prev) => {
-      if (prev.some((edge) => edge.node.id === result.chatMessage!.id)) {
-        return prev;
-      }
-      return insertEdgeSorted(prev, newEdge);
-    });
+    const sent = result.chatMessage;
+    setMessages((prev) => appendMessage(prev, sent));
 
     // Update last message in the room list
-    onLastMessageUpdate(roomId, result.chatMessage);
+    onLastMessageUpdate(roomId, sent);
   };
 
   const handleSendMedia = async (
@@ -439,19 +428,11 @@ export function ConversationView({
       throw new Error("Send message failed");
     }
 
-    // 4. Append message to list (same dedup logic as handleSendText)
-    const newEdge: Edge<ChatMessageNode> = {
-      cursor: sendResult.chatMessage.id,
-      node: sendResult.chatMessage,
-    };
-    setMessages((prev) => {
-      if (prev.some((edge) => edge.node.id === sendResult.chatMessage!.id)) {
-        return prev;
-      }
-      return insertEdgeSorted(prev, newEdge);
-    });
+    // 4. Append message to list
+    const sent = sendResult.chatMessage;
+    setMessages((prev) => appendMessage(prev, sent));
 
-    onLastMessageUpdate(roomId, sendResult.chatMessage);
+    onLastMessageUpdate(roomId, sent);
   };
 
   const handleEdit = async (messageId: string, content: string) => {

--- a/src/components/chat/conversation-view.tsx
+++ b/src/components/chat/conversation-view.tsx
@@ -9,6 +9,7 @@ import {
   updateMessage,
 } from "@/app/[locale]/chat/actions";
 import { requestChatMediaUpload } from "@/app/[locale]/upload/actions";
+import { toast } from "@/components/ui/toast";
 import { TypographyMuted } from "@/components/ui/typography";
 import type { Edge, PageInfo } from "@/lib/graphql-connection";
 import { uploadToS3 } from "@/lib/s3-upload";
@@ -22,8 +23,8 @@ import type {
 import type { ChatEvent } from "@/lib/types/chat-event";
 import { isUserChatMessage } from "@/lib/types/chat-guards";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
-import { toast } from "@/components/ui/toast";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { hasReconnectGap, reconcileMessages } from "./chat-thread-utils";
 import { ConversationHeader } from "./conversation-header";
 import { DeleteMessageDialog } from "./delete-message-dialog";
 import { DmDisabledBanner } from "./dm-disabled-banner";
@@ -40,6 +41,19 @@ interface ConversationViewProps {
   incomingEventVersion: number;
   getIncomingEvent: () => ChatEvent | null;
   reconnectCounter: number;
+}
+
+/** True when the edited message's node changed (or vanished) — closes the editor rather than risk silently applying a stale edit. */
+function didUserMessageChange(
+  prev: ChatMessageNode | undefined,
+  next: ChatMessageNode,
+): boolean {
+  if (!prev) return true; // gone/replaced → treat as changed
+  if (!isUserChatMessage(prev) || !isUserChatMessage(next)) return true;
+  return (
+    prev.updatedDate !== next.updatedDate ||
+    prev.deletedDate !== next.deletedDate
+  );
 }
 
 export function ConversationView({
@@ -68,6 +82,104 @@ export function ConversationView({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [messageToDelete, setMessageToDelete] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Mirror refs so the async reconnect closure can read the LATEST values
+  // without a stale-closure bug (the effect only re-runs on
+  // `reconnectCounter`/`roomId`, not on every messages/editingMessageId change).
+  const messagesRef = useRef(messages);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+  const editingMessageIdRef = useRef(editingMessageId);
+  useEffect(() => {
+    editingMessageIdRef.current = editingMessageId;
+  }, [editingMessageId]);
+
+  // Live in-session deletes of already-loaded originals; combined with the
+  // authoritative `replyTo.deletedDate` (selected on load) this drives the
+  // reply-quote deleted-first check in both loaded-data and live cases.
+  const deletedMessageIds = useMemo(
+    () =>
+      new Set(
+        messages
+          .filter((e) => isUserChatMessage(e.node) && e.node.deletedDate)
+          .map((e) => e.node.id),
+      ),
+    [messages],
+  );
+
+  /** Clear + non-blocking notice. Runs on remote edit/delete AND on reconcile. */
+  const abandonEdit = useCallback(() => {
+    setEditingMessageId(null);
+    toast.add({ title: t("notices.editingInterrupted"), type: "info" });
+  }, [t]);
+
+  const handleIncomingMessage = useCallback((message: ChatMessageNode) => {
+    setMessages((prev) => {
+      // Self-event deduplication: skip if message already exists
+      if (prev.some((edge) => edge.node.id === message.id)) {
+        return prev;
+      }
+
+      const newEdge: Edge<ChatMessageNode> = {
+        cursor: message.id,
+        node: message,
+      };
+
+      // Insert sorted by createdDate
+      const insertIndex = prev.findIndex(
+        (edge) =>
+          new Date(edge.node.createdDate).getTime() >
+          new Date(message.createdDate).getTime(),
+      );
+
+      if (insertIndex === -1) {
+        // Append to end (most common case)
+        return [...prev, newEdge];
+      }
+
+      // Insert at correct position
+      const next = [...prev];
+      next.splice(insertIndex, 0, newEdge);
+      return next;
+    });
+  }, []);
+
+  const handleIncomingUpdate = useCallback(
+    (message: ChatMessageNode) => {
+      setMessages((prev) =>
+        prev.map((edge) => {
+          if (edge.node.id === message.id) {
+            return { ...edge, node: message };
+          }
+          return edge;
+        }),
+      );
+      if (message.id === editingMessageIdRef.current) abandonEdit();
+    },
+    [abandonEdit],
+  );
+
+  const handleIncomingDelete = useCallback(
+    (message: ChatMessageNode) => {
+      setMessages((prev) =>
+        prev.map((edge) => {
+          if (edge.node.id === message.id) {
+            return { ...edge, node: message };
+          }
+          return edge;
+        }),
+      );
+      if (message.id === editingMessageIdRef.current) abandonEdit();
+      // Propagate the deletion into the composer's reply-in-progress, if any.
+      setReplyTo((r) =>
+        r && r.id === message.id
+          ? { ...r, deletedDate: new Date().toISOString() }
+          : r,
+      );
+    },
+    [abandonEdit],
+  );
 
   // Reset all state when roomId changes
   useEffect(() => {
@@ -142,86 +254,85 @@ export function ConversationView({
         break;
       // Member events are handled in ChatLayout
     }
-  }, [incomingEventVersion, roomId, getIncomingEvent]);
+  }, [
+    incomingEventVersion,
+    roomId,
+    getIncomingEvent,
+    handleIncomingMessage,
+    handleIncomingUpdate,
+    handleIncomingDelete,
+  ]);
 
-  // Handle reconnection: re-fetch messages
+  // Reconnect: reconcile the recent window into the existing thread — never
+  // remount the pane (composer, scroll position, and draft all survive).
   useEffect(() => {
     if (reconnectCounter === 0) return; // Skip initial render
 
-    const refetch = async () => {
-      setIsLoading(true);
-      try {
-        const messagesData = await loadMessages(roomId, 25);
-        if (messagesData) {
+    const reconnect = async () => {
+      const [messagesData, roomData] = await Promise.all([
+        loadMessages(roomId, 25),
+        loadChatRoom(roomId),
+      ]);
+
+      if (roomData) {
+        setRoom(roomData);
+        onRoomLoaded(roomData); // re-sync chat-layout activeRoom/members
+        if (roomData.__typename === "DirectMessageChatRoom") {
+          setCanMessage(roomData.canMessage);
+        }
+      }
+
+      if (messagesData) {
+        const prevEdges = messagesRef.current;
+        const prevById = new Map(prevEdges.map((e) => [e.node.id, e.node]));
+
+        if (hasReconnectGap(prevEdges, messagesData.edges)) {
+          // Honest reset: the retained tail is disconnected from the newest
+          // window (>25 messages arrived while offline). Drop it and treat
+          // the newest 25 as a fresh load; adopt the fresh pageInfo so
+          // load-older resumes correctly. Grouping/separators recompute
+          // cleanly; this is the correct trade-off over stitching a
+          // corrupted middle gap.
           setMessages(messagesData.edges);
           setMessagesPageInfo(messagesData.pageInfo);
+        } else {
+          // No gap: reconcile in place. Do NOT overwrite messagesPageInfo —
+          // preserve the older-history cursor.
+          setMessages((prev) => reconcileMessages(prev, messagesData.edges));
         }
-      } catch (error) {
-        console.error("Failed to re-fetch messages on reconnect:", error);
-      } finally {
-        setIsLoading(false);
+
+        // Editor-abandon on reconcile: close the editor if the edited
+        // message's node changed (or vanished) while disconnected.
+        const editingId = editingMessageIdRef.current;
+        if (editingId) {
+          const next = messagesData.edges.find(
+            (e) => e.node.id === editingId,
+          )?.node;
+          if (next && didUserMessageChange(prevById.get(editingId), next)) {
+            abandonEdit();
+          }
+        }
       }
+      // DO NOT set isLoading — the pane never unmounts the composer.
     };
 
-    refetch();
+    reconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- t/onRoomLoaded/abandonEdit intentionally omitted (stable enough in practice; re-running this effect on their identity would refire an unwanted reconnect fetch — this effect must run ONLY on reconnectCounter/roomId)
   }, [reconnectCounter, roomId]);
 
-  const handleIncomingMessage = (message: ChatMessageNode) => {
-    setMessages((prev) => {
-      // Self-event deduplication: skip if message already exists
-      if (prev.some((edge) => edge.node.id === message.id)) {
-        return prev;
-      }
-
-      const newEdge: Edge<ChatMessageNode> = {
-        cursor: message.id,
-        node: message,
-      };
-
-      // Insert sorted by createdDate
-      const insertIndex = prev.findIndex(
-        (edge) =>
-          new Date(edge.node.createdDate).getTime() >
-          new Date(message.createdDate).getTime(),
-      );
-
-      if (insertIndex === -1) {
-        // Append to end (most common case)
-        return [...prev, newEdge];
-      }
-
-      // Insert at correct position
-      const next = [...prev];
-      next.splice(insertIndex, 0, newEdge);
-      return next;
-    });
-  };
-
-  const handleIncomingUpdate = (message: ChatMessageNode) => {
-    setMessages((prev) =>
-      prev.map((edge) => {
-        if (edge.node.id === message.id) {
-          return { ...edge, node: message };
-        }
-        return edge;
-      }),
-    );
-  };
-
-  const handleIncomingDelete = (message: ChatMessageNode) => {
-    setMessages((prev) =>
-      prev.map((edge) => {
-        if (edge.node.id === message.id) {
-          return { ...edge, node: message };
-        }
-        return edge;
-      }),
-    );
-  };
-
-  function handleSendError(result: { errorType?: string; message?: string }) {
+  function handleSendError(
+    result: { errorType?: string; message?: string },
+    attempted: { text?: string },
+  ) {
     if (result.errorType === "MutualFollowRequiredError") {
       setCanMessage(false);
+      toast.add({
+        title: attempted.text
+          ? t("errors.sendDisabledRecover", { content: attempted.text })
+          : t("errors.sendDisabledMedia"),
+        type: "error",
+      });
+      return;
     }
     toast.add({ title: result.message || t("errors.sendMessage"), type: "error" });
   }
@@ -230,7 +341,7 @@ export function ConversationView({
     const result = await sendMessage(roomId, content, replyToId);
 
     if (!result.success || !result.chatMessage) {
-      handleSendError(result);
+      handleSendError(result, { text: content });
       throw new Error("Failed to send message");
     }
 
@@ -249,12 +360,13 @@ export function ConversationView({
 
     // Update last message in the room list
     onLastMessageUpdate(roomId, result.chatMessage);
-
-    // Clear reply state
-    setReplyTo(null);
   };
 
-  const handleSendMedia = async (file: File) => {
+  const handleSendMedia = async (
+    file: File,
+    caption?: string,
+    replyToId?: string,
+  ) => {
     // 1. Request upload
     const uploadResult = await requestChatMediaUpload(
       file.name,
@@ -276,10 +388,16 @@ export function ConversationView({
       }
     }
 
-    // 3. Send media message (auto-confirms resource -- do NOT call confirmUpload)
-    const sendResult = await sendMediaMessage(roomId, uploadResult.resourceId);
+    // 3. Send media message + caption + reply target, one message
+    //    (auto-confirms resource -- do NOT call confirmUpload)
+    const sendResult = await sendMediaMessage(
+      roomId,
+      uploadResult.resourceId,
+      caption,
+      replyToId,
+    );
     if (!sendResult.success || !sendResult.chatMessage) {
-      handleSendError(sendResult);
+      handleSendError(sendResult, { text: caption });
       throw new Error("Send message failed");
     }
 
@@ -362,22 +480,24 @@ export function ConversationView({
     setIsDeleting(false);
   };
 
-  const handleLoadOlder = async () => {
-    if (!messagesPageInfo?.hasPreviousPage || isLoadingOlder) return;
+  /** Resolves to false only on an actual fetch failure (so the list can toast + re-arm the trigger). A guarded no-op (already loading / no more pages) resolves true. */
+  const handleLoadOlder = async (): Promise<boolean> => {
+    if (!messagesPageInfo?.hasPreviousPage || isLoadingOlder) return true;
 
     setIsLoadingOlder(true);
-    const result = await loadMessages(
-      roomId,
-      25,
-      messagesPageInfo.startCursor || undefined,
-    );
-
-    if (result) {
+    try {
+      const result = await loadMessages(
+        roomId,
+        25,
+        messagesPageInfo.startCursor || undefined,
+      );
+      if (!result) return false;
       setMessages((prev) => [...result.edges, ...prev]);
       setMessagesPageInfo(result.pageInfo);
+      return true;
+    } finally {
+      setIsLoadingOlder(false);
     }
-
-    setIsLoadingOlder(false);
   };
 
   const openDeleteDialog = (messageId: string) => {
@@ -395,7 +515,7 @@ export function ConversationView({
   if (isLoading) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <TypographyMuted>Loading...</TypographyMuted>
+        <TypographyMuted>{t("loading.conversation")}</TypographyMuted>
       </div>
     );
   }
@@ -421,6 +541,7 @@ export function ConversationView({
         messages={messages}
         currentUserId={currentUser.id}
         currentUserRole={currentUserRole}
+        deletedMessageIds={deletedMessageIds}
         onReply={(message) => setReplyTo(message)}
         onDelete={openDeleteDialog}
         onLoadOlder={handleLoadOlder}

--- a/src/components/chat/conversation-view.tsx
+++ b/src/components/chat/conversation-view.tsx
@@ -44,6 +44,29 @@ interface ConversationViewProps {
 }
 
 /** True when the edited message's node changed (or vanished) — closes the editor rather than risk silently applying a stale edit. */
+/**
+ * Insert an edge maintaining ascending createdDate order — buildThreadItems
+ * requires it, and every producer (incoming events, optimistic sends,
+ * reconcile) must uphold it or grouping/day separators mis-render.
+ */
+function insertEdgeSorted(
+  prev: Edge<ChatMessageNode>[],
+  newEdge: Edge<ChatMessageNode>,
+): Edge<ChatMessageNode>[] {
+  const insertIndex = prev.findIndex(
+    (edge) =>
+      new Date(edge.node.createdDate).getTime() >
+      new Date(newEdge.node.createdDate).getTime(),
+  );
+  if (insertIndex === -1) {
+    // Append to end (most common case)
+    return [...prev, newEdge];
+  }
+  const next = [...prev];
+  next.splice(insertIndex, 0, newEdge);
+  return next;
+}
+
 function didUserMessageChange(
   prev: ChatMessageNode | undefined,
   next: ChatMessageNode,
@@ -126,22 +149,7 @@ export function ConversationView({
         node: message,
       };
 
-      // Insert sorted by createdDate
-      const insertIndex = prev.findIndex(
-        (edge) =>
-          new Date(edge.node.createdDate).getTime() >
-          new Date(message.createdDate).getTime(),
-      );
-
-      if (insertIndex === -1) {
-        // Append to end (most common case)
-        return [...prev, newEdge];
-      }
-
-      // Insert at correct position
-      const next = [...prev];
-      next.splice(insertIndex, 0, newEdge);
-      return next;
+      return insertEdgeSorted(prev, newEdge);
     });
   }, []);
 
@@ -268,11 +276,18 @@ export function ConversationView({
   useEffect(() => {
     if (reconnectCounter === 0) return; // Skip initial render
 
+    // Staleness guard: if the user switches rooms while the reconnect fetch
+    // is in flight, the resolved data belongs to the old room and must not
+    // be written over the new room's state (mirrors the roomId check in the
+    // WebSocket event handlers).
+    let cancelled = false;
+
     const reconnect = async () => {
       const [messagesData, roomData] = await Promise.all([
         loadMessages(roomId, 25),
         loadChatRoom(roomId),
       ]);
+      if (cancelled) return;
 
       if (roomData) {
         setRoom(roomData);
@@ -285,15 +300,28 @@ export function ConversationView({
       if (messagesData) {
         const prevEdges = messagesRef.current;
         const prevById = new Map(prevEdges.map((e) => [e.node.id, e.node]));
+        const gap = hasReconnectGap(prevEdges, messagesData.edges);
 
-        if (hasReconnectGap(prevEdges, messagesData.edges)) {
+        if (gap) {
           // Honest reset: the retained tail is disconnected from the newest
           // window (>25 messages arrived while offline). Drop it and treat
           // the newest 25 as a fresh load; adopt the fresh pageInfo so
           // load-older resumes correctly. Grouping/separators recompute
           // cleanly; this is the correct trade-off over stitching a
-          // corrupted middle gap.
-          setMessages(messagesData.edges);
+          // corrupted middle gap. Functional update: WebSocket messages that
+          // arrived DURING this fetch live in prev at/after the incoming
+          // window's oldest timestamp — keep those, drop only the stale tail.
+          const oldestIncoming = Date.parse(
+            messagesData.edges[0]?.node.createdDate ?? "",
+          );
+          setMessages((prev) =>
+            reconcileMessages(
+              prev.filter(
+                (e) => Date.parse(e.node.createdDate) >= oldestIncoming,
+              ),
+              messagesData.edges,
+            ),
+          );
           setMessagesPageInfo(messagesData.pageInfo);
         } else {
           // No gap: reconcile in place. Do NOT overwrite messagesPageInfo —
@@ -302,13 +330,20 @@ export function ConversationView({
         }
 
         // Editor-abandon on reconcile: close the editor if the edited
-        // message's node changed (or vanished) while disconnected.
+        // message's node changed while disconnected — or, on the gap path,
+        // if it fell outside the fresh window entirely (its bubble is gone;
+        // leaving editing state pointing at an unloaded id would resurface
+        // an inexplicable open editor if history later reloads it).
         const editingId = editingMessageIdRef.current;
         if (editingId) {
           const next = messagesData.edges.find(
             (e) => e.node.id === editingId,
           )?.node;
-          if (next && didUserMessageChange(prevById.get(editingId), next)) {
+          if (next) {
+            if (didUserMessageChange(prevById.get(editingId), next)) {
+              abandonEdit();
+            }
+          } else if (gap) {
             abandonEdit();
           }
         }
@@ -317,6 +352,9 @@ export function ConversationView({
     };
 
     reconnect();
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- t/onRoomLoaded/abandonEdit intentionally omitted (stable enough in practice; re-running this effect on their identity would refire an unwanted reconnect fetch — this effect must run ONLY on reconnectCounter/roomId)
   }, [reconnectCounter, roomId]);
 
@@ -355,7 +393,7 @@ export function ConversationView({
       if (prev.some((edge) => edge.node.id === result.chatMessage!.id)) {
         return prev;
       }
-      return [...prev, newEdge];
+      return insertEdgeSorted(prev, newEdge);
     });
 
     // Update last message in the room list
@@ -410,7 +448,7 @@ export function ConversationView({
       if (prev.some((edge) => edge.node.id === sendResult.chatMessage!.id)) {
         return prev;
       }
-      return [...prev, newEdge];
+      return insertEdgeSorted(prev, newEdge);
     });
 
     onLastMessageUpdate(roomId, sendResult.chatMessage);

--- a/src/components/chat/day-separator.tsx
+++ b/src/components/chat/day-separator.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Marker, MarkerContent } from "@/components/ui/marker";
-import { classifyDayLabel } from "./chat-thread-utils";
 import { useFormatter, useNow, useTranslations } from "next-intl";
+import { classifyDayLabel } from "./chat-thread-utils";
 
 interface DaySeparatorProps {
   /** === the day's first message's createdDate; used only to derive the label. */
@@ -24,17 +24,24 @@ export function DaySeparator({ timestamp }: DaySeparatorProps) {
   const now = useNow();
 
   const kind = classifyDayLabel(timestamp, now);
-  const label =
-    kind.kind === "today"
-      ? t("today")
-      : kind.kind === "yesterday"
-        ? tTime("yesterday")
-        : format.dateTime(
-            new Date(timestamp),
-            kind.withYear
-              ? { month: "long", day: "numeric", year: "numeric" }
-              : { month: "long", day: "numeric" },
-          );
+
+  let label: string;
+  switch (kind.kind) {
+    case "today":
+      label = t("today");
+      break;
+    case "yesterday":
+      label = tTime("yesterday");
+      break;
+    case "date":
+      label = format.dateTime(
+        new Date(timestamp),
+        kind.withYear
+          ? { month: "long", day: "numeric", year: "numeric" }
+          : { month: "long", day: "numeric" },
+      );
+      break;
+  }
 
   return (
     <Marker

--- a/src/components/chat/day-separator.tsx
+++ b/src/components/chat/day-separator.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Marker, MarkerContent } from "@/components/ui/marker";
+import { classifyDayLabel } from "./chat-thread-utils";
+import { useFormatter, useNow, useTranslations } from "next-intl";
+
+interface DaySeparatorProps {
+  /** === the day's first message's createdDate; used only to derive the label. */
+  timestamp: string;
+}
+
+/**
+ * Renders the localized day-boundary label ("Today" / "Yesterday" / absolute
+ * date). Decorative only — `aria-hidden` so it's never announced as content
+ * (distinct from system notices, which ARE announced; see system-message-bubble.tsx).
+ *
+ * `now` is captured once via `useNow()` (no interval): relative labels need
+ * not update live across midnight while the thread stays open.
+ */
+export function DaySeparator({ timestamp }: DaySeparatorProps) {
+  const t = useTranslations("chat.thread");
+  const tTime = useTranslations("chat.time");
+  const format = useFormatter();
+  const now = useNow();
+
+  const kind = classifyDayLabel(timestamp, now);
+  const label =
+    kind.kind === "today"
+      ? t("today")
+      : kind.kind === "yesterday"
+        ? tTime("yesterday")
+        : format.dateTime(
+            new Date(timestamp),
+            kind.withYear
+              ? { month: "long", day: "numeric", year: "numeric" }
+              : { month: "long", day: "numeric" },
+          );
+
+  return (
+    <Marker variant="separator" aria-hidden="true" className="my-2">
+      <MarkerContent>{label}</MarkerContent>
+    </Marker>
+  );
+}

--- a/src/components/chat/day-separator.tsx
+++ b/src/components/chat/day-separator.tsx
@@ -37,7 +37,12 @@ export function DaySeparator({ timestamp }: DaySeparatorProps) {
           );
 
   return (
-    <Marker variant="separator" aria-hidden="true" className="my-2">
+    <Marker
+      variant="separator"
+      aria-hidden="true"
+      className="my-2"
+      data-testid="day-separator"
+    >
       <MarkerContent>{label}</MarkerContent>
     </Marker>
   );

--- a/src/components/chat/member-list-panel.tsx
+++ b/src/components/chat/member-list-panel.tsx
@@ -27,14 +27,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { TypographyMuted, TypographySmall } from "@/components/ui/typography";
 import { useRouter } from "@/i18n/navigation";
 import { ChatRoomRole, ChatRoomRoleBadgeVariant } from "@/lib/constants";
 import type { Edge } from "@/lib/graphql-connection";
 import type { ChatRoomMemberNode, ChatRoomRole as ChatRoomRoleType } from "@/lib/types/chat";
-import { getFullName } from "@/lib/utils";
 import { LogOut, UserPlus } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useTranslations } from "next-intl";
+import { useFormatter, useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 import { toast } from "@/components/ui/toast";
 import { RemoveMemberDialog } from "./remove-member-dialog";
@@ -75,6 +75,7 @@ export function MemberListPanel({
   const router = useRouter();
   const t = useTranslations("chat.members");
   const tChat = useTranslations("chat");
+  const format = useFormatter();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [selectedMemberIds, setSelectedMemberIds] = useState<number[]>([]);
   const [isPending, startTransition] = useTransition();
@@ -264,7 +265,7 @@ export function MemberListPanel({
                 {members.map((edge) => {
                   const member = edge.node;
                   const isCurrentUser = member.user.id === currentUserId;
-                  const memberName = getFullName(member.user);
+                  const memberName = member.user.displayName;
 
                   return (
                     <div
@@ -273,10 +274,10 @@ export function MemberListPanel({
                     >
                       <div className="flex-1">
                         <div className="flex items-center gap-2">
-                          <span className="font-medium text-sm">
+                          <TypographySmall className="font-medium">
                             {memberName}
-                            {isCurrentUser && " (You)"}
-                          </span>
+                            {isCurrentUser && ` (${t("you")})`}
+                          </TypographySmall>
                           {!isDirectMessage && (
                             <Badge
                               variant={ChatRoomRoleBadgeVariant[member.role]}
@@ -290,13 +291,14 @@ export function MemberListPanel({
                             </Badge>
                           )}
                         </div>
-                        <div className="text-xs text-muted-foreground">
+                        <TypographyMuted className="text-xs">
                           {t("joined", {
-                            date: new Date(
-                              member.joinedDate,
-                            ).toLocaleDateString(),
+                            date: format.dateTime(
+                              new Date(member.joinedDate),
+                              { dateStyle: "medium" },
+                            ),
                           })}
-                        </div>
+                        </TypographyMuted>
                       </div>
 
                       {!isDirectMessage && !isCurrentUser && (

--- a/src/components/chat/message-actions-menu.tsx
+++ b/src/components/chat/message-actions-menu.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import { Edit, MoreHorizontal, Reply, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -16,6 +17,7 @@ interface MessageActionsMenuProps {
   onReply: () => void;
   onEdit?: () => void;
   onDelete: () => void;
+  className?: string;
 }
 
 export function MessageActionsMenu({
@@ -24,6 +26,7 @@ export function MessageActionsMenu({
   onReply,
   onEdit,
   onDelete,
+  className,
 }: MessageActionsMenuProps) {
   const t = useTranslations("chat.message");
 
@@ -34,7 +37,13 @@ export function MessageActionsMenu({
           <Button
             variant="ghost"
             size="icon"
-            className="h-6 w-6 opacity-0 group-hover:opacity-100 focus:opacity-100"
+            aria-label={t("moreActions")}
+            className={cn(
+              // ≥44px touch target on mobile; reverts to the original,
+              // subtle 24px control on desktop (icon itself stays h-4 w-4).
+              "size-11 opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 motion-safe:transition-opacity md:size-6",
+              className,
+            )}
           />
         }
       >

--- a/src/components/chat/message-bubble.tsx
+++ b/src/components/chat/message-bubble.tsx
@@ -1,13 +1,26 @@
 "use client";
 
+import {
+  Attachment,
+  AttachmentActions,
+  AttachmentContent,
+  AttachmentDescription,
+  AttachmentMedia,
+  AttachmentTitle,
+  AttachmentTrigger,
+} from "@/components/ui/attachment";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Bubble, BubbleContent } from "@/components/ui/bubble";
 import { Button } from "@/components/ui/button";
+import {
+  Message,
+  MessageAvatar,
+  MessageContent,
+  MessageFooter,
+  MessageHeader,
+} from "@/components/ui/message";
 import { Textarea } from "@/components/ui/textarea";
-import type {
-  ChatMessageReplyTo,
-  ChatRoomRole,
-  UserChatMessageNode,
-} from "@/lib/types/chat";
+import type { ChatRoomRole, UserChatMessageNode } from "@/lib/types/chat";
 import { formatFileSize, isVideoMimeType } from "@/lib/upload-validation";
 import { cn, getInitials } from "@/lib/utils";
 import { Download, FileIcon } from "lucide-react";
@@ -15,15 +28,18 @@ import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
 import { formatMessageTime } from "./chat-utils";
 import { MessageActionsMenu } from "./message-actions-menu";
+import { getReplyPreviewContent } from "./message-preview-utils";
 import { ReplyPreview } from "./reply-preview";
 
 interface MessageBubbleProps {
   message: UserChatMessageNode;
   isOwn: boolean;
-  showSender: boolean;
-  isFirstInGroup: boolean;
+  /** Avatar + name + time shown; forced true after a day boundary. */
+  isGroupStart: boolean;
   currentUserRole: ChatRoomRole | null;
   isEditing: boolean;
+  /** Originals deleted live during this session (see conversation-view). */
+  deletedMessageIds: ReadonlySet<string>;
   onReply: () => void;
   onStartEdit: () => void;
   onSaveEdit: (content: string) => void;
@@ -32,27 +48,13 @@ interface MessageBubbleProps {
   onScrollToReply: (messageId: string) => void;
 }
 
-function getReplyPreviewContent(
-  replyTo: ChatMessageReplyTo,
-  t: (key: string) => string,
-): string {
-  if (replyTo.__typename === "TextChatMessage") {
-    return replyTo.content ?? t("deleted");
-  }
-  // MediaChatMessage reply
-  if (replyTo.resource.__typename === "ImageResource") {
-    return replyTo.caption ?? t("imageAttachment");
-  }
-  return replyTo.caption ?? t("fileAttachment");
-}
-
 export function MessageBubble({
   message,
   isOwn,
-  showSender,
-  isFirstInGroup,
+  isGroupStart,
   currentUserRole,
   isEditing,
+  deletedMessageIds,
   onReply,
   onStartEdit,
   onSaveEdit,
@@ -73,13 +75,17 @@ export function MessageBubble({
   const isDeleted = message.deletedDate !== null;
   const canDelete = currentUserRole === "OWNER" || currentUserRole === "ADMIN";
   const isTextMessage = message.__typename === "TextChatMessage";
-
-  const userName = message.user.displayName;
+  const displayName = message.user.displayName;
   const initials = getInitials(message.user);
+  const time = formatMessageTime(message.createdDate, locale, timeLabels);
 
   const handleSaveEdit = () => {
     const trimmedContent = editContent.trim();
-    if (trimmedContent && isTextMessage && trimmedContent !== message.content) {
+    if (
+      trimmedContent &&
+      isTextMessage &&
+      trimmedContent !== message.content
+    ) {
       onSaveEdit(trimmedContent);
     } else {
       onCancelEdit();
@@ -96,64 +102,49 @@ export function MessageBubble({
   };
 
   return (
-    <div
-      className={cn(
-        "flex gap-3 px-4 py-1",
-        isOwn ? "justify-end" : "justify-start",
-        isFirstInGroup && "mt-2",
-      )}
-      id={`message-${message.id}`}
-    >
-      {!isOwn && (
-        <div className="flex flex-col items-center">
-          {showSender ? (
+    <Message align={isOwn ? "end" : "start"} id={`message-${message.id}`}>
+      {!isOwn &&
+        (isGroupStart ? (
+          <MessageAvatar>
             <Avatar size="sm">
               <AvatarFallback>{initials}</AvatarFallback>
             </Avatar>
-          ) : (
-            <div className="h-6 w-6" />
-          )}
-        </div>
-      )}
+          </MessageAvatar>
+        ) : (
+          <div className="w-8 shrink-0" aria-hidden="true" />
+        ))}
 
-      <div className={cn("group/row flex max-w-[70%] items-end gap-2", isOwn && "flex-row-reverse")}>
-        <div className={cn("flex min-w-0 flex-col", isOwn && "items-end")}>
-          {showSender && (
-            <div
-              className={cn(
-                "mb-1 flex items-center gap-2 px-3 text-sm",
-                isOwn && "flex-row-reverse",
-              )}
-            >
-              <span className="font-semibold">{userName}</span>
-              <span className="text-muted-foreground text-xs">
-                {formatMessageTime(message.createdDate, locale, timeLabels)}
-              </span>
-            </div>
-          )}
+      <MessageContent>
+        {isGroupStart && (
+          <MessageHeader className="gap-2">
+            <span className="font-semibold text-foreground">
+              {displayName}
+            </span>
+            <span>{time}</span>
+          </MessageHeader>
+        )}
 
-          <div
-            className={cn(
-            "group relative w-fit max-w-full rounded-lg px-3 py-2 before:pointer-events-none before:absolute before:-inset-x-4 before:-top-4 before:-bottom-1 before:content-[''] before:group-hover:pointer-events-auto",
-            isOwn
-              ? "bg-primary text-primary-foreground"
-              : "bg-muted text-foreground",
-            isDeleted && "italic opacity-70",
-          )}
+        <Bubble
+          variant={isOwn ? "default" : "muted"}
+          align={isOwn ? "end" : "start"}
         >
-          <div className="min-w-0">
+          <BubbleContent className={cn(isDeleted && "italic opacity-70")}>
             {message.replyTo && (
               <div className="mb-2">
                 <ReplyPreview
                   userName={message.replyTo.user.displayName}
-                  content={getReplyPreviewContent(message.replyTo, t)}
+                  content={getReplyPreviewContent(
+                    message.replyTo,
+                    t,
+                    deletedMessageIds,
+                  )}
                   onClick={() => onScrollToReply(message.replyTo!.id)}
                 />
               </div>
             )}
 
             {isDeleted ? (
-              <div className="text-sm">{t("deleted")}</div>
+              <div>{t("deleted")}</div>
             ) : isEditing && isTextMessage ? (
               <div className="flex flex-col gap-2">
                 <Textarea
@@ -174,15 +165,16 @@ export function MessageBubble({
               </div>
             ) : isTextMessage ? (
               <>
-                <div className="whitespace-pre-wrap break-words text-sm">
+                <div className="whitespace-pre-wrap break-words">
                   {message.content}
                 </div>
                 {message.updatedDate && (
-                  <span className="ml-2 text-xs opacity-70">{t("edited")}</span>
+                  <span className="ml-2 text-xs opacity-70">
+                    {t("edited")}
+                  </span>
                 )}
               </>
             ) : (
-              // MediaChatMessage
               <div className="space-y-2">
                 {message.resource.__typename === "ImageResource" ? (
                   <a
@@ -211,64 +203,67 @@ export function MessageBubble({
                     Your browser does not support the video element.
                   </video>
                 ) : (
-                  <a
-                    href={message.resource.downloadUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={cn(
-                      "flex items-center gap-3 rounded-md border p-3",
-                      isOwn ? "border-primary-foreground/20" : "border-border",
-                    )}
-                  >
-                    <FileIcon className="h-8 w-8 shrink-0 opacity-70" />
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium">
+                  <Attachment state="done">
+                    <AttachmentTrigger
+                      render={
+                        <a
+                          href={message.resource.downloadUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={message.resource.filename}
+                        />
+                      }
+                    />
+                    <AttachmentMedia variant="icon">
+                      <FileIcon />
+                    </AttachmentMedia>
+                    <AttachmentContent>
+                      <AttachmentTitle>
                         {message.resource.filename}
-                      </div>
-                      <div className="text-xs opacity-70">
+                      </AttachmentTitle>
+                      <AttachmentDescription>
                         {formatFileSize(message.resource.size)}
-                      </div>
-                    </div>
-                    <Download className="h-4 w-4 shrink-0 opacity-70" />
-                  </a>
+                      </AttachmentDescription>
+                    </AttachmentContent>
+                    <AttachmentActions>
+                      <Download
+                        aria-hidden="true"
+                        className="size-4 opacity-70"
+                      />
+                    </AttachmentActions>
+                  </Attachment>
                 )}
                 {message.caption && (
-                  <div className="whitespace-pre-wrap break-words text-sm">
+                  <div className="whitespace-pre-wrap break-words">
                     {message.caption}
                   </div>
                 )}
               </div>
             )}
-
-          </div>
+          </BubbleContent>
 
           {!isDeleted && !isEditing && (
-            <div
+            <MessageActionsMenu
+              isOwn={isOwn}
+              canDelete={canDelete}
+              onReply={onReply}
+              onEdit={isOwn && isTextMessage ? onStartEdit : undefined}
+              onDelete={onDelete}
               className={cn(
                 "absolute top-0 -translate-y-1/2",
-                isOwn ? "left-0 -translate-x-1/2" : "right-0 translate-x-1/2",
+                "group-data-[align=end]/bubble:left-0 group-data-[align=end]/bubble:-translate-x-1/2",
+                "group-data-[align=start]/bubble:right-0 group-data-[align=start]/bubble:translate-x-1/2",
               )}
-            >
-              <MessageActionsMenu
-                isOwn={isOwn}
-                canDelete={canDelete}
-                onReply={onReply}
-                onEdit={isOwn && isTextMessage ? onStartEdit : undefined}
-                onDelete={onDelete}
-              />
-            </div>
+            />
           )}
-        </div>
-        </div>
+        </Bubble>
 
-        {!showSender && !isDeleted && (
-          <span className="shrink-0 text-xs text-muted-foreground opacity-0 group-hover/row:opacity-100">
-            {formatMessageTime(message.createdDate, locale, timeLabels)}
-          </span>
+        {!isGroupStart && !isDeleted && (
+          <MessageFooter className="opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 motion-safe:transition-opacity">
+            {time}
+          </MessageFooter>
         )}
-      </div>
-
-      {isOwn && <div className="h-6 w-6" />}
-    </div>
+      </MessageContent>
+    </Message>
   );
 }

--- a/src/components/chat/message-bubble.tsx
+++ b/src/components/chat/message-bubble.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/message";
 import { Textarea } from "@/components/ui/textarea";
 import type { ChatRoomRole, UserChatMessageNode } from "@/lib/types/chat";
+import type { Resource } from "@/lib/types/resource";
 import { formatFileSize, isVideoMimeType } from "@/lib/upload-validation";
 import { cn, getInitials } from "@/lib/utils";
 import { Download, FileIcon } from "lucide-react";
@@ -30,6 +31,67 @@ import { formatMessageTime } from "./chat-utils";
 import { MessageActionsMenu } from "./message-actions-menu";
 import { getReplyPreviewContent } from "./message-preview-utils";
 import { ReplyPreview } from "./reply-preview";
+
+/** Image, inline video, or downloadable-file rendering for a media message. */
+function MediaContent({ resource }: { resource: Resource }) {
+  if (resource.__typename === "ImageResource") {
+    return (
+      <a
+        href={resource.downloadUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element -- user-uploaded image hosted on the backend file server; converting to next/image requires adding images.remotePatterns in next.config and handling unknown intrinsic dimensions */}
+        <img
+          src={resource.thumbnailUrl ?? resource.downloadUrl}
+          alt={resource.filename}
+          className="max-h-64 rounded-md object-cover"
+        />
+      </a>
+    );
+  }
+
+  if (isVideoMimeType(resource.mimeType)) {
+    return (
+      <video
+        controls
+        preload="metadata"
+        className="max-h-64 max-w-full rounded-md"
+        src={resource.downloadUrl}
+      >
+        Your browser does not support the video element.
+      </video>
+    );
+  }
+
+  return (
+    <Attachment state="done">
+      <AttachmentTrigger
+        render={
+          <a
+            href={resource.downloadUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={resource.filename}
+          />
+        }
+      />
+      <AttachmentMedia variant="icon">
+        <FileIcon />
+      </AttachmentMedia>
+      <AttachmentContent>
+        <AttachmentTitle>{resource.filename}</AttachmentTitle>
+        <AttachmentDescription>
+          {formatFileSize(resource.size)}
+        </AttachmentDescription>
+      </AttachmentContent>
+      <AttachmentActions>
+        <Download aria-hidden="true" className="size-4 opacity-70" />
+      </AttachmentActions>
+    </Attachment>
+  );
+}
 
 interface MessageBubbleProps {
   message: UserChatMessageNode;
@@ -101,6 +163,59 @@ export function MessageBubble({
     }
   };
 
+  /** The bubble's body: deleted placeholder, editor, text, or media. */
+  function renderBody() {
+    if (isDeleted) {
+      return <div>{t("deleted")}</div>;
+    }
+
+    if (message.__typename === "TextChatMessage") {
+      if (isEditing) {
+        return (
+          <div className="flex flex-col gap-2">
+            <Textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="min-h-[60px] w-full resize-none"
+              autoFocus
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleSaveEdit}>
+                {t("save")}
+              </Button>
+              <Button size="sm" variant="outline" onClick={onCancelEdit}>
+                {t("cancel")}
+              </Button>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <>
+          <div className="whitespace-pre-wrap break-words">
+            {message.content}
+          </div>
+          {message.updatedDate && (
+            <span className="ml-2 text-xs opacity-70">{t("edited")}</span>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <div className="space-y-2">
+        <MediaContent resource={message.resource} />
+        {message.caption && (
+          <div className="whitespace-pre-wrap break-words">
+            {message.caption}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <Message align={isOwn ? "end" : "start"} id={`message-${message.id}`}>
       {!isOwn &&
@@ -143,103 +258,7 @@ export function MessageBubble({
               </div>
             )}
 
-            {isDeleted ? (
-              <div>{t("deleted")}</div>
-            ) : isEditing && isTextMessage ? (
-              <div className="flex flex-col gap-2">
-                <Textarea
-                  value={editContent}
-                  onChange={(e) => setEditContent(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  className="min-h-[60px] w-full resize-none"
-                  autoFocus
-                />
-                <div className="flex gap-2">
-                  <Button size="sm" onClick={handleSaveEdit}>
-                    {t("save")}
-                  </Button>
-                  <Button size="sm" variant="outline" onClick={onCancelEdit}>
-                    {t("cancel")}
-                  </Button>
-                </div>
-              </div>
-            ) : isTextMessage ? (
-              <>
-                <div className="whitespace-pre-wrap break-words">
-                  {message.content}
-                </div>
-                {message.updatedDate && (
-                  <span className="ml-2 text-xs opacity-70">
-                    {t("edited")}
-                  </span>
-                )}
-              </>
-            ) : (
-              <div className="space-y-2">
-                {message.resource.__typename === "ImageResource" ? (
-                  <a
-                    href={message.resource.downloadUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block"
-                  >
-                    {/* eslint-disable-next-line @next/next/no-img-element -- user-uploaded image hosted on the backend file server; converting to next/image requires adding images.remotePatterns in next.config and handling unknown intrinsic dimensions */}
-                    <img
-                      src={
-                        message.resource.thumbnailUrl ??
-                        message.resource.downloadUrl
-                      }
-                      alt={message.resource.filename}
-                      className="max-h-64 rounded-md object-cover"
-                    />
-                  </a>
-                ) : isVideoMimeType(message.resource.mimeType) ? (
-                  <video
-                    controls
-                    preload="metadata"
-                    className="max-h-64 max-w-full rounded-md"
-                    src={message.resource.downloadUrl}
-                  >
-                    Your browser does not support the video element.
-                  </video>
-                ) : (
-                  <Attachment state="done">
-                    <AttachmentTrigger
-                      render={
-                        <a
-                          href={message.resource.downloadUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={message.resource.filename}
-                        />
-                      }
-                    />
-                    <AttachmentMedia variant="icon">
-                      <FileIcon />
-                    </AttachmentMedia>
-                    <AttachmentContent>
-                      <AttachmentTitle>
-                        {message.resource.filename}
-                      </AttachmentTitle>
-                      <AttachmentDescription>
-                        {formatFileSize(message.resource.size)}
-                      </AttachmentDescription>
-                    </AttachmentContent>
-                    <AttachmentActions>
-                      <Download
-                        aria-hidden="true"
-                        className="size-4 opacity-70"
-                      />
-                    </AttachmentActions>
-                  </Attachment>
-                )}
-                {message.caption && (
-                  <div className="whitespace-pre-wrap break-words">
-                    {message.caption}
-                  </div>
-                )}
-              </div>
-            )}
+            {renderBody()}
           </BubbleContent>
 
           {!isDeleted && !isEditing && (

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/lib/upload-validation";
 import { Loader2, SendHorizontal } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ChatAttachmentMenu } from "./chat-attachment-menu";
 import { ChatAttachmentPreview } from "./chat-attachment-preview";
 import { getMessagePreviewContent } from "./message-preview-utils";
@@ -67,16 +67,22 @@ export function MessageInput({
     };
   }, [attachmentPreviewUrl]);
 
+  // Current reply prop, readable after awaits — the closure's `replyTo` is
+  // frozen at send time, but a reply staged mid-send must not be cleared.
+  const replyToRef = useRef(replyTo);
+  replyToRef.current = replyTo;
+
   const handleSend = async () => {
     if (!canSend) return;
     const urlAtSend = attachmentPreviewUrl; // capture for safe revoke
+    const sentReplyId = replyTo?.id; // capture: clear only the reply we sent
     setIsSending(true);
     try {
       if (hasFile) {
         // media + caption + replyToId, one message
-        await onSendMedia(attachedFile!, trimmed || undefined, replyTo?.id);
+        await onSendMedia(attachedFile!, trimmed || undefined, sentReplyId);
       } else {
-        await onSendText(trimmed, replyTo?.id);
+        await onSendText(trimmed, sentReplyId);
       }
       // Success only: clear staged state and revoke the URL captured at
       // send start (never a newly-staged URL, never leaked).
@@ -85,7 +91,11 @@ export function MessageInput({
       setAttachedFile(null);
       setAttachmentPreviewUrl(null);
       setAttachmentError(null);
-      onClearReply();
+      // Clear only the reply this send carried — a reply staged from the
+      // message list DURING the in-flight send must survive.
+      if (replyToRef.current?.id === sentReplyId) {
+        onClearReply();
+      }
     } catch {
       // Failure: KEEP content + attachment + reply for retry (toast
       // surfaced by conversation-view). DM send-disabled: composer will be
@@ -156,6 +166,7 @@ export function MessageInput({
             userName={replyTo.user.displayName}
             content={getMessagePreviewContent(replyTo, t)}
             onDismiss={onClearReply}
+            dismissDisabled={isSending}
           />
         </div>
       )}

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -2,6 +2,8 @@
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { TypographyMuted } from "@/components/ui/typography";
+import { CHAT_MESSAGE_MAX_LENGTH } from "@/lib/constants";
 import type { UserChatMessageNode } from "@/lib/types/chat";
 import {
   getMaxSizeLabel,
@@ -17,8 +19,12 @@ import { getMessagePreviewContent } from "./message-preview-utils";
 import { ReplyPreview } from "./reply-preview";
 
 interface MessageInputProps {
-  onSendText: (content: string, replyToId?: string) => void;
-  onSendMedia: (file: File) => Promise<void>;
+  onSendText: (content: string, replyToId?: string) => Promise<void>;
+  onSendMedia: (
+    file: File,
+    caption?: string,
+    replyToId?: string,
+  ) => Promise<void>;
   replyTo: UserChatMessageNode | null;
   onClearReply: () => void;
   disabled?: boolean;
@@ -33,14 +39,26 @@ export function MessageInput({
 }: MessageInputProps) {
   const t = useTranslations("chat.message");
   const tMedia = useTranslations("chat.media");
+
+  // `content` doubles as text AND caption (single field) — the composer is a
+  // coexistence state machine: reply preview, attachment preview, and this
+  // field may all be present at once.
   const [content, setContent] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [attachedFile, setAttachedFile] = useState<File | null>(null);
   const [attachmentPreviewUrl, setAttachmentPreviewUrl] = useState<
     string | null
   >(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
-  const [isUploadingMedia, setIsUploadingMedia] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+
+  const trimmed = content.trim();
+  const isOverLimit = content.length > CHAT_MESSAGE_MAX_LENGTH;
+  const hasFile = attachedFile !== null;
+  const canSend =
+    !isSending &&
+    !disabled &&
+    !isOverLimit &&
+    (hasFile ? !attachmentError : trimmed.length > 0);
 
   // Cleanup preview URL on unmount or file change
   useEffect(() => {
@@ -49,57 +67,46 @@ export function MessageInput({
     };
   }, [attachmentPreviewUrl]);
 
-  const handleSendText = async () => {
-    const trimmedContent = content.trim();
-    if (!trimmedContent || isSubmitting || disabled) return;
-
-    setIsSubmitting(true);
+  const handleSend = async () => {
+    if (!canSend) return;
+    const urlAtSend = attachmentPreviewUrl; // capture for safe revoke
+    setIsSending(true);
     try {
-      await onSendText(trimmedContent, replyTo?.id);
+      if (hasFile) {
+        // media + caption + replyToId, one message
+        await onSendMedia(attachedFile!, trimmed || undefined, replyTo?.id);
+      } else {
+        await onSendText(trimmed, replyTo?.id);
+      }
+      // Success only: clear staged state and revoke the URL captured at
+      // send start (never a newly-staged URL, never leaked).
+      if (urlAtSend) URL.revokeObjectURL(urlAtSend);
       setContent("");
-      onClearReply();
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleSendMedia = async () => {
-    if (!attachedFile || isUploadingMedia) return;
-    setIsUploadingMedia(true);
-    try {
-      await onSendMedia(attachedFile);
-      // Success: clear attachment
-      if (attachmentPreviewUrl) URL.revokeObjectURL(attachmentPreviewUrl);
       setAttachedFile(null);
       setAttachmentPreviewUrl(null);
       setAttachmentError(null);
+      onClearReply();
     } catch {
-      // Error already toasted by ConversationView.handleSendMedia
-      if (attachmentPreviewUrl) URL.revokeObjectURL(attachmentPreviewUrl);
-      setAttachedFile(null);
-      setAttachmentPreviewUrl(null);
+      // Failure: KEEP content + attachment + reply for retry (toast
+      // surfaced by conversation-view). DM send-disabled: composer will be
+      // replaced by the banner; nothing to clear here.
     } finally {
-      setIsUploadingMedia(false);
-    }
-  };
-
-  const handleSend = async () => {
-    if (attachedFile) {
-      await handleSendMedia();
-    } else {
-      await handleSendText();
+      setIsSending(false);
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      handleSendText();
+      void handleSend();
     }
+    // Shift+Enter: default newline behavior.
   };
 
   const handleFileSelected = useCallback(
     (file: File) => {
+      if (isSending) return; // defense in depth against a queued event mid-send
+
       const validation = validateFile(file, "chatMedia");
       if (!validation.valid) {
         setAttachmentError(
@@ -112,42 +119,38 @@ export function MessageInput({
         setAttachedFile(file);
         if (attachmentPreviewUrl) URL.revokeObjectURL(attachmentPreviewUrl);
         setAttachmentPreviewUrl(null);
-        // Clear reply when attaching a file
-        onClearReply();
         return;
       }
 
       setAttachmentError(null);
       setAttachedFile(file);
 
-      // Create preview URL for images
       if (attachmentPreviewUrl) URL.revokeObjectURL(attachmentPreviewUrl);
-      if (isImageMimeType(file.type)) {
-        setAttachmentPreviewUrl(URL.createObjectURL(file));
-      } else {
-        setAttachmentPreviewUrl(null);
-      }
+      setAttachmentPreviewUrl(
+        isImageMimeType(file.type) ? URL.createObjectURL(file) : null,
+      );
 
-      // Clear reply when attaching a file
-      onClearReply();
+      // Reply and typed content are intentionally left untouched: attaching
+      // media no longer clears an active reply, and a caption can be typed
+      // alongside staged media. No programmatic focus (no forced mobile
+      // keyboard).
     },
-    [attachmentPreviewUrl, onClearReply, tMedia],
+    [isSending, attachmentPreviewUrl, tMedia],
   );
 
   const handleRemoveAttachment = useCallback(() => {
+    if (isSending) return; // defense in depth against a queued event mid-send
+
     if (attachmentPreviewUrl) URL.revokeObjectURL(attachmentPreviewUrl);
     setAttachedFile(null);
     setAttachmentPreviewUrl(null);
     setAttachmentError(null);
-  }, [attachmentPreviewUrl]);
-
-  const isSendDisabled = attachedFile
-    ? !!attachmentError || disabled || isUploadingMedia
-    : !content.trim() || disabled || isSubmitting;
+    // `content` is retained — the caption becomes ordinary text.
+  }, [isSending, attachmentPreviewUrl]);
 
   return (
     <div className="border-t bg-background p-4">
-      {replyTo && !attachedFile && (
+      {replyTo && (
         <div className="mb-2">
           <ReplyPreview
             userName={replyTo.user.displayName}
@@ -164,6 +167,7 @@ export function MessageInput({
             previewUrl={attachmentPreviewUrl}
             error={attachmentError}
             onRemove={handleRemoveAttachment}
+            disabled={isSending}
           />
         </div>
       )}
@@ -171,33 +175,39 @@ export function MessageInput({
       <div className="flex gap-2">
         <ChatAttachmentMenu
           onFileSelected={handleFileSelected}
-          disabled={disabled || isSubmitting || isUploadingMedia}
+          disabled={disabled || isSending}
         />
 
-        {!attachedFile && (
-          <Textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={t("placeholder")}
-            disabled={disabled || isSubmitting}
-            className="min-h-[60px] resize-none"
-          />
-        )}
+        <Textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={hasFile ? t("captionPlaceholder") : t("placeholder")}
+          disabled={disabled || isSending}
+          className="min-h-[60px] resize-none"
+        />
 
         <Button
           onClick={handleSend}
-          disabled={isSendDisabled}
+          disabled={!canSend}
           size="icon"
           className="h-[60px] w-[60px] shrink-0"
         >
-          {isUploadingMedia ? (
+          {isSending ? (
             <Loader2 className="h-5 w-5 animate-spin motion-reduce:animate-none" />
           ) : (
             <SendHorizontal className="h-5 w-5" />
           )}
         </Button>
       </div>
+
+      {isOverLimit && (
+        <TypographyMuted className="mt-1 text-destructive">
+          {hasFile
+            ? t("captionTooLong", { limit: CHAT_MESSAGE_MAX_LENGTH })
+            : t("messageTooLong", { limit: CHAT_MESSAGE_MAX_LENGTH })}
+        </TypographyMuted>
+      )}
     </div>
   );
 }

--- a/src/components/chat/message-input.tsx
+++ b/src/components/chat/message-input.tsx
@@ -192,6 +192,7 @@ export function MessageInput({
           disabled={!canSend}
           size="icon"
           className="h-[60px] w-[60px] shrink-0"
+          aria-label={t("send")}
         >
           {isSending ? (
             <Loader2 className="h-5 w-5 animate-spin motion-reduce:animate-none" />

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -177,9 +177,11 @@ function MessageListInner({
     const success = await onLoadOlder();
     if (!success) {
       toast.add({ title: t("errors.loadOlder"), type: "error" });
-      // Re-arm: the consumed true→false transition otherwise wouldn't
-      // re-fire on a subsequent scroll-away/scroll-back to the top.
-      prevStart.current = true;
+      // No re-arm here: setting prevStart back to true would be consumed by
+      // the very next effect run (isLoadingOlder flipping is a dependency),
+      // creating an unbounded fetch/toast loop under real network latency.
+      // Retry is the natural start false→true→false transition: scroll away
+      // and back to the top.
     }
   }, [onLoadOlder, t]);
 

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -58,21 +58,8 @@ function flashHighlight(messageId: string) {
   window.setTimeout(() => el.classList.remove("bg-accent/20"), 1000);
 }
 
-export function MessageList({
-  messages,
-  currentUserId,
-  currentUserRole,
-  deletedMessageIds,
-  onReply,
-  onDelete,
-  onLoadOlder,
-  hasOlderMessages,
-  isLoadingOlder,
-  editingMessageId,
-  onStartEdit,
-  onSaveEdit,
-  onCancelEdit,
-}: MessageListProps) {
+export function MessageList(props: MessageListProps) {
+  const { isLoadingOlder } = props;
   const t = useTranslations("chat");
   const prefersReducedMotion = usePrefersReducedMotion();
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -89,22 +76,7 @@ export function MessageList({
             className="gap-1 py-4"
             aria-busy={isLoadingOlder || undefined}
           >
-            <MessageListInner
-              messages={messages}
-              currentUserId={currentUserId}
-              currentUserRole={currentUserRole}
-              deletedMessageIds={deletedMessageIds}
-              onReply={onReply}
-              onDelete={onDelete}
-              onLoadOlder={onLoadOlder}
-              hasOlderMessages={hasOlderMessages}
-              isLoadingOlder={isLoadingOlder}
-              editingMessageId={editingMessageId}
-              onStartEdit={onStartEdit}
-              onSaveEdit={onSaveEdit}
-              onCancelEdit={onCancelEdit}
-              viewportRef={viewportRef}
-            />
+            <MessageListInner {...props} viewportRef={viewportRef} />
           </MessageScrollerContent>
         </MessageScrollerViewport>
 

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -36,7 +36,7 @@ interface MessageListProps {
   deletedMessageIds: ReadonlySet<string>;
   onReply: (message: UserChatMessageNode) => void;
   onDelete: (messageId: string) => void;
-  /** Resolves to false on failure so the list can toast + re-arm the trigger. */
+  /** Resolves to false on failure so the list can toast. Retry is the natural scroll-away/scroll-back transition — deliberately no automatic re-arm (see triggerLoadOlder). */
   onLoadOlder: () => Promise<boolean>;
   hasOlderMessages: boolean;
   isLoadingOlder: boolean;

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -1,7 +1,18 @@
 "use client";
 
-import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+} from "@/components/ui/message-scroller";
 import { TypographyMuted } from "@/components/ui/typography";
+import { toast } from "@/components/ui/toast";
+import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 import type { Edge } from "@/lib/graphql-connection";
 import type {
   ChatMessageNode,
@@ -11,8 +22,9 @@ import type {
 import { isUserChatMessage } from "@/lib/types/chat-guards";
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
-import { shouldShowSender } from "./chat-utils";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { buildThreadItems } from "./chat-thread-utils";
+import { DaySeparator } from "./day-separator";
 import { MessageBubble } from "./message-bubble";
 import { SystemMessageBubble } from "./system-message-bubble";
 
@@ -20,9 +32,12 @@ interface MessageListProps {
   messages: Edge<ChatMessageNode>[];
   currentUserId: number;
   currentUserRole: ChatRoomRole | null;
+  /** Originals deleted live during this session (see conversation-view). */
+  deletedMessageIds: ReadonlySet<string>;
   onReply: (message: UserChatMessageNode) => void;
   onDelete: (messageId: string) => void;
-  onLoadOlder: () => void;
+  /** Resolves to false on failure so the list can toast + re-arm the trigger. */
+  onLoadOlder: () => Promise<boolean>;
   hasOlderMessages: boolean;
   isLoadingOlder: boolean;
   editingMessageId: string | null;
@@ -31,10 +46,23 @@ interface MessageListProps {
   onCancelEdit: () => void;
 }
 
+/** Briefly highlights a jumped-to message; content-visibility:auto items stay in the DOM. */
+function flashHighlight(messageId: string) {
+  const el = document.getElementById(`message-${messageId}`);
+  if (!el) return;
+  // Permanent (idempotent) transition classes so the highlight fades for
+  // motion-safe users; under reduced motion the class toggle is instant but
+  // still shows a brief static background.
+  el.classList.add("motion-safe:transition-colors", "duration-700");
+  el.classList.add("bg-accent/20");
+  window.setTimeout(() => el.classList.remove("bg-accent/20"), 1000);
+}
+
 export function MessageList({
   messages,
   currentUserId,
   currentUserRole,
+  deletedMessageIds,
   onReply,
   onDelete,
   onLoadOlder,
@@ -46,204 +74,202 @@ export function MessageList({
   onCancelEdit,
 }: MessageListProps) {
   const t = useTranslations("chat");
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
-  const isInitialMount = useRef(true);
-  const previousMessageCount = useRef(messages.length);
-  const scrollHeightBeforeLoad = useRef<number | null>(null);
-  const [showNewMessageIndicator, setShowNewMessageIndicator] = useState(false);
-  const isNearBottomRef = useRef(true);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const viewportRef = useRef<HTMLDivElement>(null);
 
-  const getViewport = () =>
-    scrollAreaRef.current?.querySelector<HTMLDivElement>(
-      '[data-slot="scroll-area-viewport"]',
-    );
+  return (
+    <MessageScrollerProvider
+      autoScroll
+      defaultScrollPosition="end"
+      scrollEdgeThreshold={100}
+    >
+      <MessageScroller className="flex-1">
+        <MessageScrollerViewport ref={viewportRef} aria-label={t("thread.ariaLabel")}>
+          <MessageScrollerContent
+            className="gap-1 py-4"
+            aria-busy={isLoadingOlder || undefined}
+          >
+            <MessageListInner
+              messages={messages}
+              currentUserId={currentUserId}
+              currentUserRole={currentUserRole}
+              deletedMessageIds={deletedMessageIds}
+              onReply={onReply}
+              onDelete={onDelete}
+              onLoadOlder={onLoadOlder}
+              hasOlderMessages={hasOlderMessages}
+              isLoadingOlder={isLoadingOlder}
+              editingMessageId={editingMessageId}
+              onStartEdit={onStartEdit}
+              onSaveEdit={onSaveEdit}
+              onCancelEdit={onCancelEdit}
+              viewportRef={viewportRef}
+            />
+          </MessageScrollerContent>
+        </MessageScrollerViewport>
 
-  // Auto-scroll to bottom on initial mount
-  useEffect(() => {
-    if (isInitialMount.current && messages.length > 0) {
-      const viewport = getViewport();
-      if (viewport) {
-        requestAnimationFrame(() => {
-          viewport.scrollTop = viewport.scrollHeight;
-          isInitialMount.current = false;
-        });
-      }
+        {/* Load-older indicator: absolute overlay, sibling of Viewport — NOT a Content child */}
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 z-10 flex justify-center pt-2"
+          aria-hidden="true"
+        >
+          {isLoadingOlder && (
+            <TypographyMuted className="rounded-full bg-background/90 px-3 py-1 shadow-sm">
+              {t("loading.messages")}
+            </TypographyMuted>
+          )}
+        </div>
+
+        <MessageScrollerButton
+          direction="end"
+          behavior={prefersReducedMotion ? "auto" : "smooth"}
+          aria-label={t("thread.jumpToLatest")}
+        />
+      </MessageScroller>
+    </MessageScrollerProvider>
+  );
+}
+
+interface MessageListInnerProps extends MessageListProps {
+  viewportRef: React.RefObject<HTMLDivElement | null>;
+}
+
+/**
+ * Hooks that depend on `MessageScrollerProvider` context (`useMessageScroller`,
+ * `useMessageScrollerScrollable`) must be called from a component rendered
+ * INSIDE the provider — they throw outside it. Hence this inner component.
+ */
+function MessageListInner({
+  messages,
+  currentUserId,
+  currentUserRole,
+  deletedMessageIds,
+  onReply,
+  onDelete,
+  onLoadOlder,
+  hasOlderMessages,
+  isLoadingOlder,
+  editingMessageId,
+  onStartEdit,
+  onSaveEdit,
+  onCancelEdit,
+  viewportRef,
+}: MessageListInnerProps) {
+  const t = useTranslations("chat");
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const { scrollToMessage } = useMessageScroller();
+  const { start } = useMessageScrollerScrollable();
+
+  const messageNodes = useMemo(() => messages.map((e) => e.node), [messages]);
+  const threadItems = useMemo(
+    () => buildThreadItems(messageNodes),
+    [messageNodes],
+  );
+
+  // Edge-triggered load-older: fire only on the true→false transition of
+  // `start` (the top edge becoming unreachable), never level-triggered —
+  // `useMessageScrollerScrollable` starts as a placeholder before
+  // measurement and updates on a deferred rAF, so a level-triggered check
+  // would eagerly fetch on every mount and double-fire in the stale window.
+  const prevStart = useRef(start);
+
+  const triggerLoadOlder = useCallback(async () => {
+    const success = await onLoadOlder();
+    if (!success) {
+      toast.add({ title: t("errors.loadOlder"), type: "error" });
+      // Re-arm: the consumed true→false transition otherwise wouldn't
+      // re-fire on a subsequent scroll-away/scroll-back to the top.
+      prevStart.current = true;
     }
-  }, [messages.length]);
+  }, [onLoadOlder, t]);
 
-  // Scroll detection: track if user is near bottom and clear indicator when they scroll back
   useEffect(() => {
-    const viewport = getViewport();
-    if (!viewport) return;
-
-    const handleScroll = () => {
-      const nearBottom =
-        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <
-        100;
-      isNearBottomRef.current = nearBottom;
-
-      if (nearBottom) {
-        setShowNewMessageIndicator(false);
-      }
-    };
-
-    viewport.addEventListener("scroll", handleScroll);
-    return () => viewport.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  // Auto-scroll to bottom when new messages are added (not when loading older)
-  useEffect(() => {
-    if (
-      !isInitialMount.current &&
-      messages.length > previousMessageCount.current
-    ) {
-      const viewport = getViewport();
-      if (viewport) {
-        if (isNearBottomRef.current) {
-          requestAnimationFrame(() => {
-            viewport.scrollTop = viewport.scrollHeight;
-          });
-        } else {
-          // User is scrolled up -- show indicator
-          // Use queueMicrotask to defer state update and avoid synchronous setState in effect
-          queueMicrotask(() => {
-            setShowNewMessageIndicator(true);
-          });
-        }
-      }
+    const was = prevStart.current;
+    prevStart.current = start;
+    if (was && !start && hasOlderMessages && !isLoadingOlder) {
+      void triggerLoadOlder();
     }
-    previousMessageCount.current = messages.length;
-  }, [messages.length]);
+  }, [start, hasOlderMessages, isLoadingOlder, triggerLoadOlder]);
 
-  // Preserve scroll position after older messages are prepended
-  useEffect(() => {
-    if (scrollHeightBeforeLoad.current === null) return;
-
-    const viewport = getViewport();
-    if (!viewport) return;
-
-    const previousHeight = scrollHeightBeforeLoad.current;
-    scrollHeightBeforeLoad.current = null;
-    viewport.scrollTop = viewport.scrollHeight - previousHeight;
-  }, [messages.length]);
-
-  // Intersection observer for loading older messages
+  // Short-thread fallback: if the top edge is never reachable (thread
+  // shorter than the viewport), `start` never transitions. Measure the
+  // viewport directly, guarded against a failure busy-loop by only firing
+  // when the item count changed since the last attempt.
+  const lastFallbackCount = useRef(-1);
   useEffect(() => {
     if (!hasOlderMessages || isLoadingOlder) return;
-
-    const viewport = getViewport();
-    if (!viewport || !sentinelRef.current) return;
-
-    observerRef.current = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && !isLoadingOlder) {
-          scrollHeightBeforeLoad.current = viewport.scrollHeight;
-          onLoadOlder();
-        }
-      },
-      {
-        root: viewport,
-        rootMargin: "100px",
-        threshold: 0.1,
-      },
-    );
-
-    observerRef.current.observe(sentinelRef.current);
-
-    return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
+    if (lastFallbackCount.current === threadItems.length) return;
+    const raf = requestAnimationFrame(() => {
+      const vp = viewportRef.current;
+      if (vp && vp.scrollHeight <= vp.clientHeight) {
+        lastFallbackCount.current = threadItems.length;
+        void triggerLoadOlder();
       }
-    };
-  }, [hasOlderMessages, isLoadingOlder, onLoadOlder]);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [hasOlderMessages, isLoadingOlder, threadItems.length, viewportRef, triggerLoadOlder]);
 
-  const scrollToMessage = (messageId: string) => {
-    const element = document.getElementById(`message-${messageId}`);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "center" });
-      // Brief highlight effect
-      element.classList.add("bg-accent/20");
-      setTimeout(() => {
-        element.classList.remove("bg-accent/20");
-      }, 1000);
-    }
-  };
-
-  const messageNodes = messages.map((edge) => edge.node);
-  const groupingInfo = messageNodes.map((_, index) =>
-    shouldShowSender(messageNodes, index),
+  const onScrollToReply = useCallback(
+    (messageId: string) => {
+      const ok = scrollToMessage(messageId, {
+        align: "center",
+        // JS scroll — CSS `motion-safe` classes don't affect `scrollTo`.
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+      });
+      if (!ok) {
+        toast.add({ title: t("notices.originalNotAvailable"), type: "info" });
+        return;
+      }
+      flashHighlight(messageId);
+    },
+    [scrollToMessage, prefersReducedMotion, t],
   );
 
   return (
-    <ScrollArea ref={scrollAreaRef} className="flex-1">
-      <div className="flex flex-col pb-4 pt-4">
-        {/* Top sentinel for reverse infinite scroll */}
-        {hasOlderMessages && (
-          <div ref={sentinelRef} className="h-4 w-full">
-            {isLoadingOlder && (
-              <div className="flex justify-center py-2">
-                <TypographyMuted>Loading...</TypographyMuted>
-              </div>
-            )}
-          </div>
-        )}
+    <>
+      {threadItems.map((item) => {
+        const dayMarker = item.isDayStart && (
+          <DaySeparator timestamp={item.dayTimestamp} />
+        );
 
-        {/* Message bubbles */}
-        {messageNodes.map((message, index) => {
-          // System messages are rendered separately — must check BEFORE accessing .user
-          if (!isUserChatMessage(message)) {
-            return <SystemMessageBubble key={message.id} message={message} />;
-          }
-
-          // All .user accesses are safe below this point (narrowed to UserChatMessageNode)
-          const isFirstInGroup = groupingInfo[index];
-
+        if (!isUserChatMessage(item.message)) {
           return (
+            <MessageScrollerItem
+              key={item.message.id}
+              messageId={item.message.id}
+              className={cn(item.isGroupStart && "mt-3")}
+            >
+              {dayMarker}
+              <SystemMessageBubble message={item.message} />
+            </MessageScrollerItem>
+          );
+        }
+
+        const message = item.message;
+        return (
+          <MessageScrollerItem
+            key={message.id}
+            messageId={message.id}
+            className={cn(item.isGroupStart && "mt-3")}
+          >
+            {dayMarker}
             <MessageBubble
-              key={message.id}
               message={message}
               isOwn={message.user.id === currentUserId}
-              showSender={isFirstInGroup}
-              isFirstInGroup={isFirstInGroup}
+              isGroupStart={item.isGroupStart}
               currentUserRole={currentUserRole}
               isEditing={editingMessageId === message.id}
+              deletedMessageIds={deletedMessageIds}
               onReply={() => onReply(message)}
               onStartEdit={() => onStartEdit(message.id)}
               onSaveEdit={(content) => onSaveEdit(message.id, content)}
               onCancelEdit={onCancelEdit}
               onDelete={() => onDelete(message.id)}
-              onScrollToReply={scrollToMessage}
+              onScrollToReply={onScrollToReply}
             />
-          );
-        })}
-
-        {/* New messages indicator */}
-        {showNewMessageIndicator && (
-          <div className="sticky bottom-2 flex justify-center px-4">
-            <button
-              onClick={() => {
-                const viewport = getViewport();
-                if (viewport) {
-                  viewport.scrollTo({
-                    top: viewport.scrollHeight,
-                    behavior: "smooth",
-                  });
-                }
-                setShowNewMessageIndicator(false);
-              }}
-              className={cn(
-                "rounded-full bg-primary px-4 py-1.5 text-primary-foreground",
-                "text-sm font-medium shadow-md",
-                "hover:bg-primary/90 transition-colors",
-              )}
-            >
-              {t("newMessages")}
-            </button>
-          </div>
-        )}
-      </div>
-    </ScrollArea>
+          </MessageScrollerItem>
+        );
+      })}
+    </>
   );
 }

--- a/src/components/chat/message-preview-utils.ts
+++ b/src/components/chat/message-preview-utils.ts
@@ -1,4 +1,4 @@
-import type { UserChatMessageNode } from "@/lib/types/chat";
+import type { ChatMessageReplyTo, UserChatMessageNode } from "@/lib/types/chat";
 
 /**
  * Get a preview content string for a message (for reply previews, list previews, etc.)
@@ -18,4 +18,32 @@ export function getMessagePreviewContent(
     return message.caption ?? t("imageAttachment");
   }
   return message.caption ?? t("fileAttachment");
+}
+
+/**
+ * Get a preview content string for an in-bubble reply-to quote.
+ *
+ * Tests deletion FIRST (before checking the message type): a media reply
+ * whose original was deleted must show the deleted placeholder, not
+ * "[Image]"/"[File]". `replyTo.deletedDate` is authoritative for originals
+ * deleted before load (server-resolved); `deletedIds` covers originals
+ * deleted live during this session (see conversation-view's deletedMessageIds).
+ */
+export function getReplyPreviewContent(
+  replyTo: ChatMessageReplyTo,
+  t: (key: string) => string,
+  deletedIds: ReadonlySet<string>,
+): string {
+  if (replyTo.deletedDate != null || deletedIds.has(replyTo.id)) {
+    return t("deleted");
+  }
+  if (replyTo.__typename === "TextChatMessage") {
+    return replyTo.content ?? t("deleted");
+  }
+  return (
+    replyTo.caption ??
+    (replyTo.resource.__typename === "ImageResource"
+      ? t("imageAttachment")
+      : t("fileAttachment"))
+  );
 }

--- a/src/components/chat/reply-preview.tsx
+++ b/src/components/chat/reply-preview.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { TypographyMuted, TypographySmall } from "@/components/ui/typography";
+import { useTranslations } from "next-intl";
 import { X } from "lucide-react";
 
 interface ReplyPreviewProps {
@@ -11,41 +12,59 @@ interface ReplyPreviewProps {
   onClick?: () => void;
 }
 
+/**
+ * One component, two contexts:
+ * - In-bubble quote (message-bubble.tsx): `onClick` only — the whole preview
+ *   renders as a keyboard-reachable `<button>` that jumps to (and highlights)
+ *   the original message.
+ * - Composer reply preview (message-input.tsx): `onDismiss` only — a `<div>`
+ *   with a ≥44px dismiss control.
+ */
 export function ReplyPreview({
   userName,
   content,
   onDismiss,
   onClick,
 }: ReplyPreviewProps) {
+  const t = useTranslations("chat.message");
   const truncatedContent = content
     ? content.length > 80
-      ? `${content.slice(0, 80)}...`
+      ? `${content.slice(0, 80)}…`
       : content
-    : "[Message deleted]";
+    : t("deleted");
+
+  const body = (
+    <div className="min-w-0 flex-1">
+      <TypographySmall className="block truncate font-semibold">
+        {userName}
+      </TypographySmall>
+      <TypographyMuted className="truncate">{truncatedContent}</TypographyMuted>
+    </div>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex w-full items-center gap-2 rounded-md border-l-4 border-primary bg-muted/50 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+      >
+        {body}
+      </button>
+    );
+  }
 
   return (
-    <div
-      className={cn(
-        "flex items-center gap-2 rounded-md border-l-4 border-primary bg-muted/50 px-3 py-2",
-        onClick && "cursor-pointer hover:bg-muted",
-      )}
-      onClick={onClick}
-    >
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-semibold">{userName}</div>
-        <div className="truncate text-sm text-muted-foreground">
-          {truncatedContent}
-        </div>
-      </div>
+    <div className="flex items-center gap-2 rounded-md border-l-4 border-primary bg-muted/50 px-3 py-2">
+      {body}
       {onDismiss && (
         <Button
+          type="button"
           variant="ghost"
-          size="icon"
-          className="h-6 w-6 shrink-0"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDismiss();
-          }}
+          size="icon-sm"
+          className="size-11 shrink-0"
+          onClick={onDismiss}
+          aria-label={t("removeReply")}
         >
           <X className="h-4 w-4" />
         </Button>

--- a/src/components/chat/reply-preview.tsx
+++ b/src/components/chat/reply-preview.tsx
@@ -9,6 +9,8 @@ interface ReplyPreviewProps {
   userName: string;
   content: string | null;
   onDismiss?: () => void;
+  /** Disable the dismiss control (e.g. while a send is in flight). */
+  dismissDisabled?: boolean;
   onClick?: () => void;
 }
 
@@ -24,6 +26,7 @@ export function ReplyPreview({
   userName,
   content,
   onDismiss,
+  dismissDisabled = false,
   onClick,
 }: ReplyPreviewProps) {
   const t = useTranslations("chat.message");
@@ -64,6 +67,7 @@ export function ReplyPreview({
           size="icon-sm"
           className="size-11 shrink-0"
           onClick={onDismiss}
+          disabled={dismissDisabled}
           aria-label={t("removeReply")}
         >
           <X className="h-4 w-4" />

--- a/src/components/chat/system-message-bubble.tsx
+++ b/src/components/chat/system-message-bubble.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TypographyMuted } from "@/components/ui/typography";
+import { Marker, MarkerContent } from "@/components/ui/marker";
 import type { SystemChatMessageNode } from "@/lib/types/chat";
 import { useTranslations } from "next-intl";
 
@@ -8,6 +8,12 @@ interface SystemMessageBubbleProps {
   message: SystemChatMessageNode;
 }
 
+/**
+ * Centered notice (no flanking lines) — deliberately distinct from a day
+ * separator so "joined/left" is never mistaken for a date. Unlike the day
+ * separator, this IS announced as content (no aria-hidden): it's real
+ * information, not decoration.
+ */
 export function SystemMessageBubble({ message }: SystemMessageBubbleProps) {
   const t = useTranslations("chat.systemMessage");
 
@@ -28,8 +34,8 @@ export function SystemMessageBubble({ message }: SystemMessageBubbleProps) {
   }
 
   return (
-    <div className="flex justify-center py-2">
-      <TypographyMuted className="italic text-sm">{text}</TypographyMuted>
-    </div>
+    <Marker className="justify-center py-2">
+      <MarkerContent className="flex-none italic">{text}</MarkerContent>
+    </Marker>
   );
 }

--- a/src/components/ui/attachment.tsx
+++ b/src/components/ui/attachment.tsx
@@ -1,0 +1,207 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+const attachmentVariants = cva(
+  "group/attachment relative flex w-fit max-w-full min-w-0 shrink-0 flex-wrap rounded-xl border bg-card text-card-foreground transition-colors focus-within:ring-1 focus-within:ring-ring/50 has-[>a,>button]:hover:bg-muted/50 data-[state=error]:border-destructive/30 data-[state=idle]:border-dashed",
+  {
+    variants: {
+      size: {
+        default:
+          "gap-2 text-sm has-data-[slot=attachment-content]:px-2.5 has-data-[slot=attachment-content]:py-2 has-data-[slot=attachment-media]:p-2",
+        sm: "gap-2.5 text-xs has-data-[slot=attachment-content]:px-2 has-data-[slot=attachment-content]:py-1.5 has-data-[slot=attachment-media]:p-1.5",
+        xs: "gap-1.5 rounded-lg text-xs has-data-[slot=attachment-content]:px-1.5 has-data-[slot=attachment-content]:py-1 has-data-[slot=attachment-media]:p-1",
+      },
+      orientation: {
+        horizontal: "min-w-40 items-center",
+        vertical: "w-24 flex-col has-data-[slot=attachment-content]:w-30",
+      },
+    },
+  }
+)
+
+function Attachment({
+  className,
+  state = "done",
+  size = "default",
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof attachmentVariants> & {
+    state?: "idle" | "uploading" | "processing" | "error" | "done"
+  }) {
+  return (
+    <div
+      data-slot="attachment"
+      data-state={state}
+      data-size={size}
+      data-orientation={orientation}
+      className={cn(attachmentVariants({ size, orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+const attachmentMediaVariants = cva(
+  "relative flex aspect-square w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-muted text-foreground group-data-[orientation=vertical]/attachment:w-full group-data-[size=sm]/attachment:w-8 group-data-[size=xs]/attachment:w-7 group-data-[size=xs]/attachment:rounded-md group-data-[state=error]/attachment:bg-destructive/10 group-data-[state=error]/attachment:text-destructive group-data-[orientation=vertical]/attachment:*:data-[slot=spinner]:size-6! [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 group-data-[orientation=vertical]/attachment:[&_svg:not([class*='size-'])]:size-6 group-data-[size=xs]/attachment:[&_svg:not([class*='size-'])]:size-3.5",
+  {
+    variants: {
+      variant: {
+        icon: "",
+        image:
+          "opacity-60 group-data-[state=done]/attachment:opacity-100 group-data-[state=idle]/attachment:opacity-100 *:[img]:aspect-square *:[img]:w-full *:[img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "icon",
+    },
+  }
+)
+
+function AttachmentMedia({
+  className,
+  variant = "icon",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof attachmentMediaVariants>) {
+  return (
+    <div
+      data-slot="attachment-media"
+      data-variant={variant}
+      className={cn(attachmentMediaVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-content"
+      className={cn(
+        "max-w-full min-w-0 flex-1 leading-tight group-data-[orientation=vertical]/attachment:px-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTitle({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="attachment-title"
+      className={cn(
+        "block max-w-full min-w-0 truncate font-medium group-data-[state=processing]/attachment:shimmer group-data-[state=uploading]/attachment:shimmer",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentDescription({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="attachment-description"
+      className={cn(
+        "mt-0.5 block min-w-0 truncate text-xs text-muted-foreground group-data-[state=error]/attachment:text-destructive/80",
+        "max-w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentActions({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-actions"
+      className={cn(
+        "relative z-20 flex shrink-0 items-center group-data-[orientation=vertical]/attachment:absolute group-data-[orientation=vertical]/attachment:top-3 group-data-[orientation=vertical]/attachment:right-3 group-data-[orientation=vertical]/attachment:gap-1",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AttachmentAction({
+  className,
+  variant,
+  size = "icon-xs",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="attachment-action"
+      variant={variant ?? "ghost"}
+      size={size}
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AttachmentTrigger({
+  className,
+  render,
+  type,
+  ...props
+}: useRender.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        type: render ? type : (type ?? "button"),
+        className: cn("absolute inset-0 z-10 outline-none", className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "attachment-trigger",
+    },
+  })
+}
+
+function AttachmentGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="attachment-group"
+      className={cn(
+        "flex min-w-0 scroll-fade-x snap-x snap-mandatory scroll-px-1 scrollbar-none gap-3 overflow-x-auto overscroll-x-contain py-1 *:data-[slot=attachment]:flex-none *:data-[slot=attachment]:snap-start",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Attachment,
+  AttachmentGroup,
+  AttachmentMedia,
+  AttachmentContent,
+  AttachmentTitle,
+  AttachmentDescription,
+  AttachmentActions,
+  AttachmentAction,
+  AttachmentTrigger,
+}

--- a/src/components/ui/bubble.tsx
+++ b/src/components/ui/bubble.tsx
@@ -1,0 +1,128 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function BubbleGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="bubble-group"
+      className={cn("flex min-w-0 flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+const bubbleVariants = cva(
+  "group/bubble relative flex w-fit max-w-[80%] min-w-0 flex-col gap-1 group-data-[align=end]/message:self-end data-[align=end]:self-end data-[variant=ghost]:max-w-full",
+  {
+    variants: {
+      variant: {
+        default:
+          "*:data-[slot=bubble-content]:bg-primary *:data-[slot=bubble-content]:text-primary-foreground [&>[data-slot=bubble-content]:is(button,a):hover]:bg-primary/80",
+        secondary:
+          "*:data-[slot=bubble-content]:bg-secondary *:data-[slot=bubble-content]:text-secondary-foreground [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)]",
+        muted:
+          "*:data-[slot=bubble-content]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[color-mix(in_oklch,var(--muted),var(--foreground)_5%)]",
+        tinted:
+          "*:data-[slot=bubble-content]:bg-[oklch(from_var(--primary)_0.93_calc(c*0.4)_h)] *:data-[slot=bubble-content]:text-foreground dark:*:data-[slot=bubble-content]:bg-[oklch(from_var(--primary)_0.3_calc(c*0.4)_h)] [&>[data-slot=bubble-content]:is(button,a):hover]:bg-[oklch(from_var(--primary)_0.88_calc(c*0.5)_h)] dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-[oklch(from_var(--primary)_0.35_calc(c*0.5)_h)]",
+        outline:
+          "*:data-[slot=bubble-content]:border-border *:data-[slot=bubble-content]:bg-background [&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:text-foreground dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-input/30",
+        ghost:
+          "border-none *:data-[slot=bubble-content]:rounded-none *:data-[slot=bubble-content]:bg-transparent *:data-[slot=bubble-content]:p-0 [&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted [&>[data-slot=bubble-content]:is(button,a):hover]:text-foreground dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-muted/50",
+        destructive:
+          "*:data-[slot=bubble-content]:bg-destructive/10 *:data-[slot=bubble-content]:text-destructive dark:*:data-[slot=bubble-content]:bg-destructive/20 [&>[data-slot=bubble-content]:is(button,a):hover]:bg-destructive/20 dark:[&>[data-slot=bubble-content]:is(button,a):hover]:bg-destructive/30",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Bubble({
+  variant = "default",
+  align = "start",
+  className,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof bubbleVariants> & {
+    align?: "start" | "end"
+  }) {
+  return (
+    <div
+      data-slot="bubble"
+      data-variant={variant}
+      data-align={align}
+      className={cn(bubbleVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function BubbleContent({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "w-fit max-w-full min-w-0 overflow-hidden rounded-xl border border-transparent px-3 py-2 text-sm leading-relaxed wrap-break-word group-data-[align=end]/bubble:self-end [button]:text-left [button,a]:transition-colors [button,a]:outline-none [button,a]:focus-visible:border-ring [button,a]:focus-visible:ring-3 [button,a]:focus-visible:ring-ring/50",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "bubble-content",
+    },
+  })
+}
+
+const bubbleReactionsVariants = cva(
+  "absolute z-10 flex w-fit shrink-0 items-center justify-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-sm ring-3 ring-card has-[button]:p-0",
+  {
+    variants: {
+      side: {
+        top: "top-0 -translate-y-3/4",
+        bottom: "bottom-0 translate-y-3/4",
+      },
+      align: {
+        start: "left-3",
+        end: "right-3",
+      },
+    },
+    defaultVariants: {
+      side: "bottom",
+      align: "end",
+    },
+  }
+)
+
+function BubbleReactions({
+  side = "bottom",
+  align = "end",
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  align?: "start" | "end"
+  side?: "top" | "bottom"
+}) {
+  return (
+    <div
+      data-slot="bubble-reactions"
+      data-align={align}
+      data-side={side}
+      className={cn(bubbleReactionsVariants({ side, align }), className)}
+      {...props}
+    />
+  )
+}
+
+export { BubbleGroup, Bubble, BubbleContent, BubbleReactions }

--- a/src/components/ui/marker.tsx
+++ b/src/components/ui/marker.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const markerVariants = cva(
+  "group/marker relative flex min-h-4 w-full items-center gap-2 text-left text-sm text-muted-foreground [&_svg:not([class*='size-'])]:size-4 [a]:underline [a]:underline-offset-3 [a]:hover:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "",
+        separator:
+          "before:mr-1 before:h-px before:min-w-0 before:flex-1 before:bg-border after:ml-1 after:h-px after:min-w-0 after:flex-1 after:bg-border",
+        border: "border-b border-border pb-2",
+      },
+    },
+  }
+)
+
+function Marker({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & VariantProps<typeof markerVariants>) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(markerVariants({ variant, className })),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "marker",
+      variant,
+    },
+  })
+}
+
+function MarkerIcon({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-icon"
+      aria-hidden="true"
+      className={cn(
+        "size-4 shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MarkerContent({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="marker-content"
+      className={cn(
+        "min-w-0 wrap-break-word group-data-[variant=separator]/marker:flex-none group-data-[variant=separator]/marker:text-center *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Marker, MarkerIcon, MarkerContent, markerVariants }

--- a/src/components/ui/message-scroller.tsx
+++ b/src/components/ui/message-scroller.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import * as React from "react"
+import {
+  MessageScroller as MessageScrollerPrimitive,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from "@shadcn/react/message-scroller"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { ArrowDownIcon } from "lucide-react"
+
+function MessageScrollerProvider(
+  props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
+) {
+  return <MessageScrollerPrimitive.Provider {...props} />
+}
+
+function MessageScroller({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Root>) {
+  return (
+    <MessageScrollerPrimitive.Root
+      data-slot="message-scroller"
+      className={cn(
+        "group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerViewport({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+  return (
+    <MessageScrollerPrimitive.Viewport
+      data-slot="message-scroller-viewport"
+      className={cn(
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Content>) {
+  return (
+    <MessageScrollerPrimitive.Content
+      data-slot="message-scroller-content"
+      className={cn("flex h-max min-h-full flex-col gap-8", className)}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerItem({
+  className,
+  scrollAnchor = false,
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+  return (
+    <MessageScrollerPrimitive.Item
+      data-slot="message-scroller-item"
+      scrollAnchor={scrollAnchor}
+      className={cn(
+        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageScrollerButton({
+  direction = "end",
+  className,
+  children,
+  render,
+  variant = "secondary",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Button> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <MessageScrollerPrimitive.Button
+      data-slot="message-scroller-button"
+      data-direction={direction}
+      data-variant={variant}
+      data-size={size}
+      direction={direction}
+      className={cn(
+        "absolute inset-s-1/2 -translate-x-1/2 border-border bg-background text-foreground transition-[translate,scale,opacity] duration-200 hover:bg-muted hover:text-foreground data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0 data-[active=false]:duration-400 data-[active=false]:ease-[cubic-bezier(0.7,0,0.84,0)] data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100 data-[active=true]:ease-[cubic-bezier(0.23,1,0.32,1)] data-[direction=end]:bottom-4 data-[direction=end]:data-[active=false]:translate-y-full data-[direction=start]:top-4 data-[direction=start]:data-[active=false]:-translate-y-full rtl:translate-x-1/2 data-[direction=start]:[&_svg]:rotate-180",
+        className
+      )}
+      render={render ?? <Button variant={variant} size={size} />}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <ArrowDownIcon
+          />
+          <span className="sr-only">
+            {direction === "end" ? "Scroll to end" : "Scroll to start"}
+          </span>
+        </>
+      )}
+    </MessageScrollerPrimitive.Button>
+  )
+}
+
+export {
+  MessageScrollerProvider,
+  MessageScroller,
+  MessageScrollerViewport,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerButton,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+}

--- a/src/components/ui/message.tsx
+++ b/src/components/ui/message.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function MessageGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-group"
+      className={cn("flex min-w-0 flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function Message({
+  className,
+  align = "start",
+  ...props
+}: React.ComponentProps<"div"> & { align?: "start" | "end" }) {
+  return (
+    <div
+      data-slot="message"
+      data-align={align}
+      className={cn(
+        "group/message relative flex w-full min-w-0 gap-2 text-sm data-[align=end]:flex-row-reverse",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageAvatar({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-avatar"
+      className={cn(
+        "flex w-fit min-w-8 shrink-0 items-center justify-center self-end overflow-hidden rounded-full bg-muted group-has-data-[slot=message-footer]/message:-translate-y-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-content"
+      className={cn(
+        "flex w-full min-w-0 flex-col gap-2.5 wrap-break-word group-data-[align=end]/message:*:data-slot:self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-header"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function MessageFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="message-footer"
+      className={cn(
+        "flex max-w-full min-w-0 items-center px-3 text-xs font-medium text-muted-foreground group-has-data-[variant=ghost]/message:px-0 group-data-[align=end]/message:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  MessageGroup,
+  Message,
+  MessageAvatar,
+  MessageContent,
+  MessageFooter,
+  MessageHeader,
+}

--- a/src/hooks/use-prefers-reduced-motion.ts
+++ b/src/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(onChange: () => void) {
+  const mediaQuery = window.matchMedia(QUERY);
+  mediaQuery.addEventListener("change", onChange);
+  return () => mediaQuery.removeEventListener("change", onChange);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false; // unknown on the server; the client re-syncs on mount
+}
+
+/**
+ * Reactive `prefers-reduced-motion` check for JS-driven behavior (e.g.
+ * `scrollIntoView`/`scrollTo` `behavior`) where Tailwind's `motion-safe:`/
+ * `motion-reduce:` variants don't apply — those only gate CSS.
+ */
+export function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -219,6 +219,11 @@ export enum ChatRoomRole {
 }
 
 /**
+ * Shared character limit for chat text messages and media captions.
+ */
+export const CHAT_MESSAGE_MAX_LENGTH = 5000;
+
+/**
  * Badge variant mapping for chat room role display
  */
 export const ChatRoomRoleBadgeVariant = {

--- a/src/lib/graphql-fragments.ts
+++ b/src/lib/graphql-fragments.ts
@@ -164,6 +164,7 @@ const userChatMessageFields = {
   replyTo: {
     __typename: true,
     id: true,
+    deletedDate: true,
     user: chatUserFragment,
     __on: [
       { __typeName: "TextChatMessage", content: true },

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -62,6 +62,8 @@ export type ChatMessageNode = UserChatMessageNode | SystemChatMessageNode;
 interface ChatMessageReplyToBase {
   id: string;
   user: ChatUser;
+  /** Present, may be null. Server-resolved: reflects the original's current state. */
+  deletedDate: string | null;
 }
 
 /** Reply-to reference for a text message */

--- a/tests/fixtures/graphql-handlers.ts
+++ b/tests/fixtures/graphql-handlers.ts
@@ -6,7 +6,7 @@ import {
   mockBasketballStatsResponse,
 } from "./mock-data/games";
 import { mockFeedResponse } from "./mock-data/feed";
-import { mockChatRoomsResponse } from "./mock-data/chat";
+import { mockChatRoomsResponse, mockSendChatMessageResponse } from "./mock-data/chat";
 import { mockSearchUsersResponse } from "./mock-data/search";
 import { mockEmptyBlockedResponse } from "./mock-data/blocked-users";
 import { mockUserResponse } from "./mock-data/user";
@@ -58,6 +58,15 @@ export const defaultGraphQLHandlers = [
   http.post("*/graphql", async ({ request }) => {
     const body = (await request.json()) as { query: string };
     const field = extractOperationField(body.query);
+
+    // sendChatMessage needs to branch on input.mediaMessage vs
+    // input.textMessage (and echo the caption/content) — the actual
+    // argument values live in the raw query text, not a separate
+    // "variables" payload, so this must inspect the query rather than a
+    // static canned response.
+    if (field === "sendChatMessage") {
+      return HttpResponse.json(mockSendChatMessageResponse(body.query));
+    }
 
     if (field && field in defaultResponses) {
       return HttpResponse.json(defaultResponses[field] as Record<string, unknown>);

--- a/tests/fixtures/mock-data/chat.ts
+++ b/tests/fixtures/mock-data/chat.ts
@@ -1,20 +1,278 @@
+import { http, HttpResponse } from "msw";
+import { OTHER_USER_ID, TEST_BACKEND_USER_ID } from "../test-ids";
+import { mockMeResponse } from "./me";
 import { buildConnection, emptyConnection } from "./connection";
 
-const defaultRoom = {
-  id: "room-1",
-  name: "Test Room",
-  lastMessage: { content: "Hello", createdAt: new Date().toISOString() },
-  members: [],
+/**
+ * Local field-name extraction (deliberately NOT imported from
+ * graphql-handlers.ts — that module imports response builders FROM this
+ * file, so importing back would create a circular dependency).
+ */
+function getOperationField(queryString: string): string | null {
+  const match = queryString.match(
+    /(?:query|mutation)?\s*(?:\w+\s*)?\{[\s]*(\w+)/,
+  );
+  return match?.[1] ?? null;
+}
+
+export const CHAT_CURRENT_USER = {
+  id: TEST_BACKEND_USER_ID,
+  firstName: "Test",
+  lastName: "User",
+  displayName: "Test User",
 };
+
+export const CHAT_OTHER_USER = {
+  id: OTHER_USER_ID,
+  firstName: "Other",
+  lastName: "Person",
+  displayName: "Other Person",
+};
+
+// ---------------------------------------------------------------------------
+// Message node builders (chatMessageNodeSelection shape)
+// ---------------------------------------------------------------------------
+
+export function mockTextMessage(overrides?: Record<string, unknown>) {
+  return {
+    __typename: "TextChatMessage",
+    id: "msg-1",
+    createdDate: new Date().toISOString(),
+    user: CHAT_OTHER_USER,
+    updatedDate: null,
+    deletedDate: null,
+    replyTo: null,
+    content: "Hello",
+    ...overrides,
+  };
+}
+
+export function mockImageResource(overrides?: Record<string, unknown>) {
+  return {
+    __typename: "ImageResource",
+    id: "resource-1",
+    filename: "photo.png",
+    size: 2048,
+    mimeType: "image/png",
+    downloadUrl: "https://cdn.example.com/photo.png",
+    createdDate: new Date().toISOString(),
+    width: 400,
+    height: 300,
+    thumbnailUrl: "https://cdn.example.com/photo-thumb.png",
+    ...overrides,
+  };
+}
+
+export function mockMediaMessage(overrides?: Record<string, unknown>) {
+  return {
+    __typename: "MediaChatMessage",
+    id: "msg-media-1",
+    createdDate: new Date().toISOString(),
+    user: CHAT_CURRENT_USER,
+    updatedDate: null,
+    deletedDate: null,
+    replyTo: null,
+    caption: null,
+    resource: mockImageResource(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Room list (chatRooms query — chatRoomListNodeSelection shape)
+// ---------------------------------------------------------------------------
+
+export function mockChatRoomListNode(overrides?: Record<string, unknown>) {
+  return {
+    __typename: "DirectMessageChatRoom",
+    id: "room-1",
+    createdDate: new Date().toISOString(),
+    canMessage: true,
+    members: {
+      edges: [{ node: { user: CHAT_CURRENT_USER } }, { node: { user: CHAT_OTHER_USER } }],
+    },
+    chatMessages: {
+      edges: [{ node: mockTextMessage() }],
+    },
+    ...overrides,
+  };
+}
 
 export function mockChatRoomsResponse(rooms?: Record<string, unknown>[]) {
   return {
     data: {
-      chatRooms: buildConnection(rooms ?? [defaultRoom]),
+      chatRooms: buildConnection(rooms ?? [mockChatRoomListNode()]),
     },
   };
 }
 
 export function mockEmptyChatRoomsResponse() {
   return { data: { chatRooms: emptyConnection() } };
+}
+
+// ---------------------------------------------------------------------------
+// Room detail (the "chatRoom" field — serves BOTH loadChatRoom and
+// loadMessages, which both select it under that same top-level field name)
+// ---------------------------------------------------------------------------
+
+export function mockChatRoomDetail(overrides?: Record<string, unknown>) {
+  return {
+    __typename: "DirectMessageChatRoom",
+    id: "room-1",
+    createdDate: new Date().toISOString(),
+    canMessage: true,
+    members: {
+      edges: [
+        {
+          cursor: "member-1",
+          node: {
+            id: "member-1",
+            user: CHAT_CURRENT_USER,
+            role: "MEMBER",
+            joinedDate: new Date().toISOString(),
+          },
+        },
+        {
+          cursor: "member-2",
+          node: {
+            id: "member-2",
+            user: CHAT_OTHER_USER,
+            role: "MEMBER",
+            joinedDate: new Date().toISOString(),
+          },
+        },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+    chatMessages: {
+      edges: [],
+      pageInfo: { hasPreviousPage: false, startCursor: null },
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// requestUpload (media send flow)
+// ---------------------------------------------------------------------------
+
+export function mockRequestUploadResponse(overrides?: Record<string, unknown>) {
+  return {
+    data: {
+      requestUpload: {
+        __typename: "RequestUploadResponse",
+        uploadUrl: null, // LOCAL storage dev environments skip the S3 PUT
+        resourceId: "resource-uploaded-1",
+        ...overrides,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// sendChatMessage — branches on input.mediaMessage vs input.textMessage since
+// the raw query text (not a separate "variables" payload) carries the input.
+// Echoes caption/content + replyToId so the composer's send-and-render flow
+// is verifiable end-to-end.
+// ---------------------------------------------------------------------------
+
+export function mockSendChatMessageResponse(queryString: string) {
+  const isMedia = /mediaMessage\s*:/.test(queryString);
+
+  if (isMedia) {
+    const caption = queryString.match(/caption\s*:\s*"([^"]*)"/)?.[1] ?? null;
+    const replyToId = queryString.match(/replyToId\s*:\s*"([^"]*)"/)?.[1];
+    const resourceId =
+      queryString.match(/resourceId\s*:\s*"([^"]*)"/)?.[1] ?? "resource-1";
+
+    return {
+      data: {
+        sendChatMessage: {
+          __typename: "SendChatMessageResponse",
+          chatMessage: mockMediaMessage({
+            id: "msg-echo-media",
+            caption,
+            resource: mockImageResource({ id: resourceId }),
+            ...(replyToId
+              ? { replyTo: { __typename: "TextChatMessage", id: replyToId, deletedDate: null, user: CHAT_OTHER_USER, content: "Original message" } }
+              : {}),
+          }),
+        },
+      },
+    };
+  }
+
+  const content = queryString.match(/content\s*:\s*"([^"]*)"/)?.[1] ?? "";
+  const replyToId = queryString.match(/replyToId\s*:\s*"([^"]*)"/)?.[1];
+
+  return {
+    data: {
+      sendChatMessage: {
+        __typename: "SendChatMessageResponse",
+        chatMessage: mockTextMessage({
+          id: "msg-echo-text",
+          content,
+          user: CHAT_CURRENT_USER,
+          ...(replyToId
+            ? { replyTo: { __typename: "TextChatMessage", id: replyToId, deletedDate: null, user: CHAT_OTHER_USER, content: "Original message" } }
+            : {}),
+        }),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Composite per-test handler: routes me/chatRooms/chatRoom/requestUpload/
+// sendChatMessage for a single open conversation. `chatRoom` serves both the
+// room-detail query AND the messages query (same top-level field); pass
+// `olderMessages` to also branch on a `before:` older-history fetch.
+// ---------------------------------------------------------------------------
+
+interface ChatConversationHandlerOptions {
+  /** Room entry for the left-pane room list (chatRooms query). */
+  roomListEntry: Record<string, unknown>;
+  /** Combined room-detail + initial chatMessages window (the "chatRoom" field). */
+  room: Record<string, unknown>;
+  /** Returned instead of `room.chatMessages` when the request's `before` cursor matches. */
+  olderMessages?: { cursor: string; chatMessages: Record<string, unknown> };
+  requestUpload?: Record<string, unknown>;
+}
+
+export function mockChatConversationHandler({
+  roomListEntry,
+  room,
+  olderMessages,
+  requestUpload,
+}: ChatConversationHandlerOptions) {
+  return http.post("*/graphql", async ({ request }) => {
+    const body = (await request.json()) as { query: string };
+    const field = getOperationField(body.query);
+
+    if (field === "me") {
+      return HttpResponse.json(mockMeResponse());
+    }
+    if (field === "chatRooms") {
+      return HttpResponse.json(mockChatRoomsResponse([roomListEntry]));
+    }
+    if (field === "chatRoom") {
+      if (
+        olderMessages &&
+        body.query.includes(`before: "${olderMessages.cursor}"`)
+      ) {
+        return HttpResponse.json({
+          data: { chatRoom: { ...room, chatMessages: olderMessages.chatMessages } },
+        });
+      }
+      return HttpResponse.json({ data: { chatRoom: room } });
+    }
+    if (field === "requestUpload") {
+      return HttpResponse.json(requestUpload ?? mockRequestUploadResponse());
+    }
+    if (field === "sendChatMessage") {
+      return HttpResponse.json(mockSendChatMessageResponse(body.query));
+    }
+
+    return HttpResponse.json({ data: {} });
+  });
 }

--- a/tests/fixtures/mock-data/chat.ts
+++ b/tests/fixtures/mock-data/chat.ts
@@ -177,46 +177,40 @@ export function mockRequestUploadResponse(overrides?: Record<string, unknown>) {
 // ---------------------------------------------------------------------------
 
 export function mockSendChatMessageResponse(queryString: string) {
-  const isMedia = /mediaMessage\s*:/.test(queryString);
-
-  if (isMedia) {
-    const caption = queryString.match(/caption\s*:\s*"([^"]*)"/)?.[1] ?? null;
-    const replyToId = queryString.match(/replyToId\s*:\s*"([^"]*)"/)?.[1];
-    const resourceId =
-      queryString.match(/resourceId\s*:\s*"([^"]*)"/)?.[1] ?? "resource-1";
-
-    return {
-      data: {
-        sendChatMessage: {
-          __typename: "SendChatMessageResponse",
-          chatMessage: mockMediaMessage({
-            id: "msg-echo-media",
-            caption,
-            resource: mockImageResource({ id: resourceId }),
-            ...(replyToId
-              ? { replyTo: { __typename: "TextChatMessage", id: replyToId, deletedDate: null, user: CHAT_OTHER_USER, content: "Original message" } }
-              : {}),
-          }),
-        },
-      },
-    };
-  }
-
-  const content = queryString.match(/content\s*:\s*"([^"]*)"/)?.[1] ?? "";
   const replyToId = queryString.match(/replyToId\s*:\s*"([^"]*)"/)?.[1];
+  const replyTo = replyToId
+    ? {
+        replyTo: {
+          __typename: "TextChatMessage",
+          id: replyToId,
+          deletedDate: null,
+          user: CHAT_OTHER_USER,
+          content: "Original message",
+        },
+      }
+    : {};
+
+  const chatMessage = /mediaMessage\s*:/.test(queryString)
+    ? mockMediaMessage({
+        id: "msg-echo-media",
+        caption: queryString.match(/caption\s*:\s*"([^"]*)"/)?.[1] ?? null,
+        resource: mockImageResource({
+          id: queryString.match(/resourceId\s*:\s*"([^"]*)"/)?.[1] ?? "resource-1",
+        }),
+        ...replyTo,
+      })
+    : mockTextMessage({
+        id: "msg-echo-text",
+        content: queryString.match(/content\s*:\s*"([^"]*)"/)?.[1] ?? "",
+        user: CHAT_CURRENT_USER,
+        ...replyTo,
+      });
 
   return {
     data: {
       sendChatMessage: {
         __typename: "SendChatMessageResponse",
-        chatMessage: mockTextMessage({
-          id: "msg-echo-text",
-          content,
-          user: CHAT_CURRENT_USER,
-          ...(replyToId
-            ? { replyTo: { __typename: "TextChatMessage", id: replyToId, deletedDate: null, user: CHAT_OTHER_USER, content: "Original message" } }
-            : {}),
-        }),
+        chatMessage,
       },
     },
   };

--- a/tests/pages/chat.spec.ts
+++ b/tests/pages/chat.spec.ts
@@ -147,7 +147,9 @@ test.describe("Chat Page", () => {
     // The day separator is decoration: hidden from assistive tech and not
     // actionable.
     await expect(daySeparators.nth(0)).toHaveAttribute("aria-hidden", "true");
-    await expect(daySeparators.nth(0).getByRole("button")).toHaveCount(0);
+    // Element-level (not role-based) query: aria-hidden empties the a11y
+    // tree, so getByRole would count 0 regardless — check real DOM instead.
+    await expect(daySeparators.nth(0).locator("button, a")).toHaveCount(0);
 
     // Sending a new message after the boundary must still work (the
     // separator doesn't break the room's send flow).

--- a/tests/pages/chat.spec.ts
+++ b/tests/pages/chat.spec.ts
@@ -1,10 +1,28 @@
 import { test, expect, withMeGuard } from "../fixtures/test-fixtures";
-import { mockEmptyChatRoomsResponse } from "../fixtures/mock-data/chat";
+import {
+  CHAT_OTHER_USER,
+  mockChatConversationHandler,
+  mockChatRoomDetail,
+  mockChatRoomListNode,
+  mockEmptyChatRoomsResponse,
+  mockTextMessage,
+} from "../fixtures/mock-data/chat";
+
+// Day-boundary logic (buildThreadItems/classifyDayLabel) uses local Date
+// getters, so the conversation-view specs pin the browser's timezone for
+// deterministic "Today" / absolute-date labeling, independent of whatever
+// timezone the test runner's OS defaults to.
+test.use({ timezoneId: "America/New_York" });
 
 const chatRoomsError = () => ({
   data: null,
   errors: [{ message: "Server error", extensions: { classification: "INTERNAL_ERROR" } }],
 });
+
+// A minimal valid 1x1 transparent PNG, used to stage a real file through the
+// composer's hidden file input without touching disk.
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
 test.describe("Chat Page", () => {
   test("[CRITICAL] unauthenticated: redirects to /", async ({
@@ -20,6 +38,8 @@ test.describe("Chat Page", () => {
     await authenticatedPage.goto("/en/chat");
     await expect(authenticatedPage).toHaveURL(/\/en\/chat/);
     await expect(authenticatedPage.locator("body")).toBeVisible();
+    // The room-list row renders the other DM participant's display name.
+    await expect(authenticatedPage.getByText(CHAT_OTHER_USER.displayName)).toBeVisible();
   });
 
   test("authenticated: error state when rooms fail to load", async ({
@@ -38,5 +58,258 @@ test.describe("Chat Page", () => {
     msw.use(withMeGuard(mockEmptyChatRoomsResponse));
     await authenticatedPage.goto("/en/chat");
     await expect(authenticatedPage).toHaveURL(/\/en\/chat/);
+    await expect(authenticatedPage.getByText("No conversations yet.")).toBeVisible();
+  });
+
+  test("day separators render at a day boundary and the send flow still works", async ({
+    authenticatedPage,
+    msw,
+  }) => {
+    // The day-boundary BUCKETING (today/yesterday/absolute-date) uses native
+    // Date getters, which respect the browser's America/New_York timezone
+    // override (`test.use({ timezoneId })` above). The absolute-date LABEL
+    // TEXT, however, is rendered by next-intl's formatter, which in this
+    // environment resolves its own (server-determined) ambient timezone
+    // rather than the browser's override. Anchoring the "older" timestamp at
+    // 16:00 UTC keeps both interpretations safely mid-day (noon EDT / 9am
+    // PDT / etc.) so they agree on the same calendar date regardless of
+    // which timezone each side actually uses — avoiding a spurious
+    // off-by-one-day mismatch between the two.
+    const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+    const nowUtc = new Date();
+    const anchorUtc = Date.UTC(
+      nowUtc.getUTCFullYear(),
+      nowUtc.getUTCMonth(),
+      nowUtc.getUTCDate(),
+      16,
+      0,
+      0,
+    );
+    const olderTimestamp = new Date(anchorUtc - THREE_DAYS_MS).toISOString();
+    // "Today" is asserted via the exact translated string (not formatted
+    // text), so it only depends on the BROWSER's (New York) bucketing — using
+    // the current instant unmodified is safe (no relative offset to
+    // spuriously cross a local-midnight boundary).
+    const todayTimestamp = new Date().toISOString();
+
+    const olderMessage = mockTextMessage({
+      id: "msg-older-day",
+      createdDate: olderTimestamp,
+      content: "Hey from a few days ago",
+      user: CHAT_OTHER_USER,
+    });
+    const todayMessage = mockTextMessage({
+      id: "msg-today",
+      createdDate: todayTimestamp,
+      content: "Hi from today",
+      user: CHAT_OTHER_USER,
+    });
+
+    const room = mockChatRoomDetail({
+      id: "room-day-boundary",
+      chatMessages: {
+        edges: [
+          { cursor: "msg-older-day", node: olderMessage },
+          { cursor: "msg-today", node: todayMessage },
+        ],
+        pageInfo: { hasPreviousPage: false, startCursor: null },
+      },
+    });
+    const roomListEntry = mockChatRoomListNode({
+      id: "room-day-boundary",
+      chatMessages: { edges: [{ node: todayMessage }] },
+    });
+
+    msw.use(mockChatConversationHandler({ roomListEntry, room }));
+
+    await authenticatedPage.goto("/en/chat?room=room-day-boundary");
+
+    // Scope thread assertions to the message-thread region (aria-label
+    // "Messages") — the room-list row's last-message preview can otherwise
+    // contain the same text and make `getByText` ambiguous.
+    const thread = authenticatedPage.getByLabel("Messages");
+    await expect(thread.getByText("Hey from a few days ago")).toBeVisible();
+    await expect(thread.getByText("Hi from today")).toBeVisible();
+
+    // Exactly one separator per calendar day: the older message's absolute
+    // date, and "Today" for the same-day message.
+    const daySeparators = authenticatedPage.getByTestId("day-separator");
+    await expect(daySeparators).toHaveCount(2);
+
+    const expectedOlderLabel = new Intl.DateTimeFormat("en-US", {
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    }).format(new Date(olderTimestamp));
+    await expect(daySeparators.nth(0)).toContainText(expectedOlderLabel);
+    await expect(daySeparators.nth(1)).toHaveText("Today");
+
+    // The day separator must not be selectable/actionable, and sending a
+    // new message afterward must still work (the boundary doesn't break the
+    // room's send flow).
+    await authenticatedPage
+      .getByPlaceholder("Type a message...")
+      .fill("Sending after the separators");
+    await authenticatedPage.getByRole("button", { name: "Send" }).click();
+    await expect(
+      thread.getByText("Sending after the separators"),
+    ).toBeVisible();
+  });
+
+  test("a captioned media message can be sent and renders with its caption", async ({
+    authenticatedPage,
+    msw,
+  }) => {
+    const room = mockChatRoomDetail({
+      id: "room-media-caption",
+      chatMessages: { edges: [], pageInfo: { hasPreviousPage: false, startCursor: null } },
+    });
+    const roomListEntry = mockChatRoomListNode({ id: "room-media-caption" });
+
+    msw.use(mockChatConversationHandler({ roomListEntry, room }));
+
+    await authenticatedPage.goto("/en/chat?room=room-media-caption");
+
+    await expect(authenticatedPage.getByPlaceholder("Type a message...")).toBeVisible();
+
+    // Stage a file directly on the hidden file input (no need to click the
+    // visible attach button first).
+    await authenticatedPage.locator('input[type="file"]').setInputFiles({
+      name: "photo.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(PNG_1X1_BASE64, "base64"),
+    });
+
+    // Composer coexistence: caption/text field is typed alongside the staged
+    // attachment (this used to be impossible — staging a file hid the field).
+    // The placeholder switches to the caption prompt once a file is staged.
+    await authenticatedPage
+      .getByPlaceholder("Add a caption…")
+      .fill("A lovely caption");
+    await authenticatedPage.getByRole("button", { name: "Send" }).click();
+
+    // MSW echoes the caption + an ImageResource back on the media branch;
+    // assert the rendered message shows both the image and the caption.
+    await expect(authenticatedPage.getByAltText("photo.png")).toBeVisible();
+    await expect(authenticatedPage.getByText("A lovely caption")).toBeVisible();
+  });
+
+  test("loading older same-day history preserves scroll position (no visual jump)", async ({
+    authenticatedPage,
+    msw,
+  }) => {
+    // All messages share the same America/New_York calendar day — this is
+    // exactly the scenario the prepend-restore blocker fix targets: day
+    // separators render INSIDE the first item of a day rather than as a
+    // standalone child, so a same-day prepend still moves the previous
+    // first item to index > 0 and the primitive's scroll-restore fires.
+    const initialCount = 40;
+    const initialMessages = Array.from({ length: initialCount }, (_, i) => {
+      const createdDate = new Date(
+        Date.parse("2025-06-10T14:00:00Z") + i * 2 * 60 * 1000,
+      ).toISOString();
+      return mockTextMessage({
+        id: `msg-${i}`,
+        createdDate,
+        content: `Message number ${i}`,
+        user: CHAT_OTHER_USER,
+      });
+    });
+
+    const olderCount = 10;
+    const olderMessages = Array.from({ length: olderCount }, (_, i) => {
+      const createdDate = new Date(
+        Date.parse("2025-06-10T12:00:00Z") + i * 2 * 60 * 1000,
+      ).toISOString();
+      return mockTextMessage({
+        id: `msg-old-${i}`,
+        createdDate,
+        content: `Older message number ${i}`,
+        user: CHAT_OTHER_USER,
+      });
+    });
+
+    const room = mockChatRoomDetail({
+      id: "room-scroll-preserve",
+      chatMessages: {
+        edges: initialMessages.map((node) => ({ cursor: node.id, node })),
+        pageInfo: { hasPreviousPage: true, startCursor: "msg-0" },
+      },
+    });
+    const roomListEntry = mockChatRoomListNode({ id: "room-scroll-preserve" });
+
+    msw.use(
+      mockChatConversationHandler({
+        roomListEntry,
+        room,
+        olderMessages: {
+          cursor: "msg-0",
+          chatMessages: {
+            edges: olderMessages.map((node) => ({ cursor: node.id, node })),
+            pageInfo: { hasPreviousPage: false, startCursor: null },
+          },
+        },
+      }),
+    );
+
+    await authenticatedPage.goto("/en/chat?room=room-scroll-preserve");
+
+    // Wait for the thread to render and auto-scroll to the bottom.
+    await expect(authenticatedPage.getByText("Message number 39")).toBeVisible();
+
+    const viewport = authenticatedPage.locator(
+      '[data-slot="message-scroller-viewport"]',
+    );
+    await expect(viewport).toBeVisible();
+
+    // The primitive publishes its measured scrollable-edge state as a
+    // `data-scrollable` attribute ("start"/"end"/both). Wait for "start" to
+    // appear before jumping to the top — the load-older trigger fires on a
+    // true→false transition, so it must have observed "true" (more to
+    // scroll toward the start) at least once first.
+    await expect(viewport).toHaveAttribute("data-scrollable", /start/);
+
+    // Scroll to the top (a real, trusted wheel gesture — not just a raw
+    // `scrollTop` property write — so the primitive's native `scroll`
+    // listener updates its internal anchor-tracking the same way it would
+    // for a real user).
+    await viewport.hover();
+    await authenticatedPage.mouse.wheel(0, -100000);
+
+    // Wait for the primitive to register that the top edge is now
+    // unreachable — this confirms its scroll-event handling (mode update +
+    // anchor re-capture) has actually run before we measure "before".
+    await expect(viewport).not.toHaveAttribute("data-scrollable", /start/);
+
+    // Capture the pre-prepend "distance from bottom" (scrollHeight -
+    // scrollTop). This is the correct invariant for "no visual jump": if the
+    // scroll-restore anchors correctly, scrollTop grows by exactly the
+    // height of the prepended content, keeping (scrollHeight - scrollTop)
+    // constant. A literal raw scrollTop equality would NOT hold here
+    // (scrollTop necessarily moves off zero once older content is
+    // prepended above it).
+    const before = await viewport.evaluate(
+      (el) => el.scrollHeight - el.scrollTop,
+    );
+
+    // Wait for the older batch to actually prepend.
+    await expect(
+      authenticatedPage.getByText("Older message number 9"),
+    ).toBeVisible();
+
+    const after = await viewport.evaluate(
+      (el) => el.scrollHeight - el.scrollTop,
+    );
+
+    // A small tolerance (not exact equality) absorbs benign noise from
+    // `content-visibility: auto` on off-screen MessageScrollerItems: their
+    // `contain-intrinsic-size` placeholder height vs. real rendered height
+    // can shift by a few pixels as different items cross the viewport
+    // boundary during the prepend. A real scroll-jump regression (the
+    // BLOCKER this test targets) would move this value by roughly the
+    // height of the entire prepended batch (hundreds of pixels), so this
+    // tolerance stays far tighter than any real regression while not being
+    // flaky over rendering noise.
+    expect(Math.abs(after - before)).toBeLessThanOrEqual(100);
   });
 });

--- a/tests/pages/chat.spec.ts
+++ b/tests/pages/chat.spec.ts
@@ -144,9 +144,13 @@ test.describe("Chat Page", () => {
     await expect(daySeparators.nth(0)).toContainText(expectedOlderLabel);
     await expect(daySeparators.nth(1)).toHaveText("Today");
 
-    // The day separator must not be selectable/actionable, and sending a
-    // new message afterward must still work (the boundary doesn't break the
-    // room's send flow).
+    // The day separator is decoration: hidden from assistive tech and not
+    // actionable.
+    await expect(daySeparators.nth(0)).toHaveAttribute("aria-hidden", "true");
+    await expect(daySeparators.nth(0).getByRole("button")).toHaveCount(0);
+
+    // Sending a new message after the boundary must still work (the
+    // separator doesn't break the room's send flow).
     await authenticatedPage
       .getByPlaceholder("Type a message...")
       .fill("Sending after the separators");
@@ -288,9 +292,20 @@ test.describe("Chat Page", () => {
     // constant. A literal raw scrollTop equality would NOT hold here
     // (scrollTop necessarily moves off zero once older content is
     // prepended above it).
-    const before = await viewport.evaluate(
-      (el) => el.scrollHeight - el.scrollTop,
-    );
+    // Atomic capture: read the measurement AND whether the older batch has
+    // already prepended in a single evaluate. If the prepend won the race
+    // (fast MSW round-trip vs. Playwright's attribute polling), `before`
+    // would be measured post-prepend and the zero-delta assertion would
+    // pass while measuring nothing — fail loudly instead so the race is
+    // visible as a flake, never as a silent hole.
+    const snapshot = await viewport.evaluate((el) => ({
+      before: el.scrollHeight - el.scrollTop,
+      olderAlreadyRendered: Array.from(
+        el.querySelectorAll('[data-slot="message-scroller-item"]'),
+      ).some((item) => item.textContent?.includes("Older message number 9")),
+    }));
+    expect(snapshot.olderAlreadyRendered).toBe(false);
+    const before = snapshot.before;
 
     // Wait for the older batch to actually prepend.
     await expect(

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,6 +11,9 @@ export default defineConfig({
     exclude: ["node_modules/**", "tests/**"],
     env: {
       SKIP_ENV_VALIDATION: "1",
+      // Pinned so date/timezone-sensitive derivations (e.g. chat-thread-utils)
+      // are deterministic in CI regardless of the host's local timezone.
+      TZ: "America/New_York",
     },
   },
 });


### PR DESCRIPTION
## Summary

Full front-of-house rebuild of chat on the shadcn chat primitives (`MessageScroller`, `Message`, `Bubble`, `Attachment`, `Marker` + the `@shadcn/react` headless package), adopting the shadcn chat look wholesale. Spec-driven: requirements and design both went through adversarial review (18 + 8 findings folded in) before implementation; docs live in `.claudedoc/chat-shadcn-revamp/`.

### What changed for users

- **New look** across the conversation, composer, room list, members panel, and create/DM dialogs. Own-vs-others distinction and light/dark legibility preserved.
- **Day separators** — "Today" / "Yesterday" / localized dates, computed in the viewer's timezone; a day boundary always restarts sender grouping (midnight-spanning runs regroup).
- **Caption-on-send** — the composer now supports reply + attachment + caption simultaneously (previously staging a file *hid* the text field, making captions impossible). Backend already supported `caption`/`replyToId`; this is client wiring only.
- **Hardened real-time**: reconnect preserves your draft, reply, attachment, and scroll position (with an honest reset when >25 messages were missed); remote edit/delete of a message you're editing closes the editor with a notice; deleted originals propagate into reply quotes; jump-to-original surfaces a notice when the target isn't loaded; a failed send that flips a DM to disabled restates your text so nothing is silently lost.
- **Accessibility**: `role=log` announcements (suppressed while history prepends), keyboard-reachable actions, reduced-motion-aware scrolling (JS `behavior:"auto"`), ≥44px touch targets, localized loading strings.

### Engineering notes

- The thread's five hand-rolled scroll effects are replaced by the primitive; day markers render *inside* each day's first item because the primitive's prepend-restore gate keys on the first Content child shifting (the design-review blocker).
- Load-older is edge-triggered with a DOM-measured short-thread fallback — deliberately **no** automatic retry re-arm (it looped unboundedly under latency; caught in review and documented at the call sites).
- Pure derivation (`chat-thread-utils`) is unit-tested under pinned `TZ` with midnight/cross-timezone/gap fixtures.
- Review chain: full-branch code review (7 findings fixed), QA vs. requirements (report + addendum committed), simplifier pass, and a tail review of the post-review commits (2 findings fixed) — every commit has independent review coverage.

## Test plan

- [x] `npm run build` / `npm run lint` (0 errors) / `npm test` — 751 passed (21 new derivation tests, 4 new action tests)
- [x] Playwright: full suite 115 passed; chat spec 7/7 including day-separator, captioned-media-send, and a race-proof zero-scroll-delta same-day-prepend assertion
- [x] QA agent verdict: ready — report at `.claudedoc/chat-shadcn-revamp/qa-report.md`
- [ ] **Manual pass required before merge**: `.claudedoc/chat-shadcn-revamp/manual-checklist.md` — WebSocket/multi-participant behaviors, reconnect-with-draft, composer state machine, mobile + screen reader + reduced motion, both themes. The Playwright harness cannot drive subscriptions, so this checklist is the real-time gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)